### PR TITLE
wip: ヘッダーレスポンシブ対応、検索機能周り（見た目）変更

### DIFF
--- a/HaCollect/src/App.vue
+++ b/HaCollect/src/App.vue
@@ -7,16 +7,24 @@
                 </router-link>
             </a>
 
-            <form action="/searchResult" method="get" id="form">
-                <input type="text" name="searchName" class="searchArea" placeholder="知りたい情報は何ですか？">
-            </form>
+            <router-link to="/searchResult">
+                <img class="searchButton" src="./assets/mushimegane.png">
+            </router-link>
+
         </div>
     </header>
     <router-view></router-view>
 </template>
 
 <script>
-
+'use strict'
+export default {
+    data() {
+        return {
+            test: '',
+        }
+    }
+}
 </script>
 
 <style>
@@ -64,7 +72,7 @@ header {
     /* 要素の重なりを指定 */
     width: 100%;
     /* 固定した要素は浮いた状態になるので、横幅100%にする */
-    height: 80px;
+    height: 70px;
 }
 
 .header-inner {
@@ -89,42 +97,39 @@ header {
     margin-top: 10px;
 }
 
-.searchArea {
-    width: 560px;
-    /* inputの幅           */
-    height: 35px;
-    background-image: url("./assets/mushimegane.png");
-    /* 背景画像：虫眼鏡(*1)*/
-    background-repeat: no-repeat;
-    /* 背景は繰り返さない  */
-    background-position: 8px center;
-    /* 背景の位置          */
-    background-size: auto 60%;
-    /* 背景のサイズ        */
+.searchButton {
+    width: 50px;
     background-color: #fff;
-    /* 背景色              */
     margin: 10px auto 0 auto;
-    /* サンプルは中央寄せ  */
-    padding-left: 30px;
-    /* 虫眼鏡分の左余白    */
     border-radius: 6px;
-    /* 角丸                */
-    color: #555;
-    /* 文字色              */
-    font-size: 18px;
-    /* フォントサイズ      */
-    letter-spacing: 0.1em;
-    /* 文字間隔            */
-    font-weight: bold;
-    /* 太字                */
-    outline: 0;
-    /* 入力薄枠を非表示    */
+    border: 2px solid #000;
 }
 
-/*テキスト入力欄にフォーカスか来たとき*/
-.searchArea:focus {
-    background-color: #cfe7ff;
-    /* フォーカス時背景色  */
+.searchButton:hover {
+    opacity: 0.8;
+    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+}
+
+@media(max-width: 800px) {
+    h1{
+        font-size: 24px;
+    }
+    .header-inner {
+        padding: 0 20px;
+    }
+
+    .header-logoImg {
+        width: 150px;
+        margin-top: 10px;
+    }
+
+    .searchButton {
+        width: 35px;
+        background-color: #fff;
+        margin: 10px auto 0 auto;
+        border-radius: 6px;
+        border: 2px solid #000;
+    }
 }
 </style>
     

--- a/HaCollect/src/components/eatPage.vue
+++ b/HaCollect/src/components/eatPage.vue
@@ -171,4 +171,18 @@ a {
 .hello {
     padding-top: 80px;
 }
+
+@media(max-width: 800px) {
+    .header-nav {
+        padding-left: 0;
+    }
+
+    .header-navList li {
+        margin: 0 10px
+    }
+
+    .header-navList li a {
+        padding: 0 5px;
+    }
+}
 </style>

--- a/HaCollect/src/components/eventPage.vue
+++ b/HaCollect/src/components/eventPage.vue
@@ -171,4 +171,18 @@ a {
 .hello {
     padding-top: 80px;
 }
+
+@media(max-width: 800px) {
+    .header-nav {
+        padding-left: 0;
+    }
+
+    .header-navList li {
+        margin: 0 10px
+    }
+
+    .header-navList li a {
+        padding: 0 5px;
+    }
+}
 </style>

--- a/HaCollect/src/components/newsPage.vue
+++ b/HaCollect/src/components/newsPage.vue
@@ -171,4 +171,18 @@ a {
 .hello {
     padding-top: 80px;
 }
+
+@media(max-width: 800px) {
+    .header-nav {
+        padding-left: 0;
+    }
+
+    .header-navList li {
+        margin: 0 10px
+    }
+
+    .header-navList li a {
+        padding: 0 5px;
+    }
+}
 </style>

--- a/HaCollect/src/components/searchResult.vue
+++ b/HaCollect/src/components/searchResult.vue
@@ -3,14 +3,22 @@
         <nav class="header-nav">
             <ul class="header-navList">
                 <li>
-                    <a><span class="nowPage">〇〇</span>の検索結果</a>
+                    <a><span class="nowPage">{{ test }}</span>の検索結果</a>
                 </li>
             </ul>
         </nav>
+
+        <input type="text" v-model="test" class="searchArea" placeholder="知りたい情報は何ですか？">
     </div>
+    <div class="header-inner3">
+        <input type="text" v-model="test" class="searchAreaSmart" placeholder="知りたい情報は何ですか？">
+    </div>
+
     <div class="hello">
+
         <img alt="Vue logo" src="../assets/logo.png">
-        <h1>これは検索結果のページです。</h1>
+        <h1>これは{{ test }}の検索結果ページです。</h1>
+        <p>{{ test }}</p>
         <p>
             For a guide and recipes on how to configure / customize this project,<br>
             check out the
@@ -71,10 +79,12 @@
 </template>
 
 <script>
+'use strict'
 export default {
-    name: 'HelloWorld',
-    props: {
-        msg: String
+    data() {
+        return {
+            test: '',
+        }
     }
 }
 </script>
@@ -106,6 +116,7 @@ a {
     width: 100%;
     margin: 0 auto;
     position: fixed;
+    height: 60px;
 }
 
 .header-nav {
@@ -136,9 +147,121 @@ a {
 
 .header-navList .nowPage {
     color: #4c9eeb;
+    text-decoration-line: underline;
+}
+
+.searchArea {
+    width: 350px;
+    /* inputの幅           */
+    height: 35px;
+    background-image: url("../assets/mushimegane.png");
+    /* 背景画像：虫眼鏡(*1)*/
+    background-repeat: no-repeat;
+    /* 背景は繰り返さない  */
+    background-position: 8px center;
+    /* 背景の位置          */
+    background-size: auto 60%;
+    /* 背景のサイズ        */
+    background-color: #fff;
+    /* 背景色              */
+    margin: 0 30px 0 auto;
+    /* サンプルは中央寄せ  */
+    padding-left: 30px;
+    /* 虫眼鏡分の左余白    */
+    border-radius: 6px;
+    /* 角丸                */
+    color: #555;
+    /* 文字色              */
+    font-size: 18px;
+    /* フォントサイズ      */
+    letter-spacing: 0.1em;
+    /* 文字間隔            */
+    font-weight: bold;
+    /* 太字                */
+    outline: 0;
+    /* 入力薄枠を非表示    */
+}
+
+/*テキスト入力欄にフォーカスか来たとき*/
+.searchArea:focus {
+    background-color: #cfe7ff;
+    /* フォーカス時背景色  */
 }
 
 .hello {
     padding-top: 80px;
+}
+
+@media(max-width: 800px) {
+    .header-inner2 {
+        height: 30px;
+        margin: 30px auto 0 auto;
+    }
+
+    .header-nav {
+        padding-left: 0;
+    }
+
+    .header-navList li {
+        margin: 0 10px
+    }
+
+    .header-navList li a {
+        padding: 0 5px;
+        font-size: 16px;
+    }
+
+    .searchArea {
+        display: none;
+    }
+
+    .header-inner3 {
+        background-color: #f5af5a;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        margin: 0 auto;
+        position: fixed;
+        height: 30px;
+    }
+
+    .searchAreaSmart {
+        width: 250px;
+        /* inputの幅           */
+        height: 20px;
+        background-image: url("../assets/mushimegane.png");
+        /* 背景画像：虫眼鏡(*1)*/
+        background-repeat: no-repeat;
+        /* 背景は繰り返さない  */
+        background-position: 8px center;
+        /* 背景の位置          */
+        background-size: auto 60%;
+        /* 背景のサイズ        */
+        background-color: #fff;
+        /* 背景色              */
+        margin: 0 auto;
+        /* サンプルは中央寄せ  */
+        padding-left: 30px;
+        /* 虫眼鏡分の左余白    */
+        border-radius: 6px;
+        /* 角丸                */
+        color: #555;
+        /* 文字色              */
+        font-size: 14px;
+        /* フォントサイズ      */
+        letter-spacing: 0.1em;
+        /* 文字間隔            */
+        font-weight: bold;
+        /* 太字                */
+        outline: 0;
+        /* 入力薄枠を非表示    */
+    }
+
+    /*テキスト入力欄にフォーカスか来たとき*/
+    .searchAreaSmart:focus {
+        background-color: #cfe7ff;
+        /* フォーカス時背景色  */
+    }
 }
 </style>

--- a/HaCollect/src/components/topPage.vue
+++ b/HaCollect/src/components/topPage.vue
@@ -176,5 +176,19 @@ a {
 .hello {
     padding-top: 80px;
 }
+
+@media(max-width: 800px) {
+    .header-nav {
+        padding-left: 0;
+    }
+
+    .header-navList li {
+        margin: 0 10px
+    }
+
+    .header-navList li a {
+        padding: 0 5px;
+    }
+}
 </style>
     

--- a/HaCollect/src/components/tourPage.vue
+++ b/HaCollect/src/components/tourPage.vue
@@ -171,4 +171,18 @@ a {
 .hello {
     padding-top: 80px;
 }
+
+@media(max-width: 800px) {
+    .header-nav {
+        padding-left: 0;
+    }
+
+    .header-navList li {
+        margin: 0 10px
+    }
+
+    .header-navList li a {
+        padding: 0 5px;
+    }
+}
 </style>


### PR DESCRIPTION
- ヘッダーのレスポンシブ対応
- 「検索バー→検索画面に遷移時入力内容持込み」だった動きを「虫眼鏡ボタン→検索画面に移動し検索バーに入力・リアルタイムで入力内容表示」に変更