### PR TITLE
add: カテゴリ横スクロール部分をApp.vueに統一

### DIFF
--- a/HaCollect/src/App.vue
+++ b/HaCollect/src/App.vue
@@ -53,13 +53,57 @@
 export default {
     data() {
         return {
-            search_text: '',    //検索バーに打ち込んだのをリアルタイムに格納
+            search_text: '',  //実際にsearchResultコンポーネントに渡すもの
             buttonActive: false,//ボタンを非表示にしておく
             scroll: 0
         }
     },
+    methods: {
+        InitializeData() {
+            this.$store.dispatch('InitializeFireData').then( () => {
+                // this.$store.dispatch('getCategoryData')  
+                this.$store.dispatch('getTopData')
+                this.$store.dispatch('getFoodData')
+                this.$store.dispatch('getNewsData')
+                this.$store.dispatch('getSpaData')
+                this.$store.dispatch('getTourData')
+            }) 
+        },
+        doSearch() {
+            try{
+                // this.$router.push('/searchResult') <-これはただ、リンク変えるだけ
+                this.$router.push({ name: 'searchResult', params: { search: this.search_text } }) //<- これはリンク先に検索したのを渡すことができる
+                this.$store.dispatch('getSearchData', this.search_text)    //検索結果ページで使うデータ(search_fire_data)をstoreから参照 -> searchResult.vueのcomputedのfire_dataに反映
+                this.search_text = '' //検索バーに検索した文字を残さないための処理
+            } catch(e) {
+                console.log('error')
+                //エラーは無視（search_textに何も入力してない時怒られるから書いた）
+            }
+        },
+        deleteText() {
+            this.search_text = '' //検索バーに検索した文字を残さないための処理
+        },
+        // ページのトップに移動する関数
+        scrollTop() {
+            window.scrollTo({
+                top: 0,  //どこに移動するか
+                behavior: 'smooth'  //ここでどのように移動するか決める smoothでゆっくり移動する
+            });
+        },
+        // ボタンが現れる関数
+        scrollWindow() {
+            const top = 100 //topから100pxスクロールしたらボタン登場
+            this.scroll = window.scrollY //垂直方向
+            if (top <= this.scroll) {
+                this.buttonActive = true   //ボタン見えるようになる
+            } else {
+                this.buttonActive = false  //ボタン見えない
+            }
+        }
+    },
     mounted() {
         window.addEventListener('scroll', this.scrollWindow)   //スクロールすると関数が察知してくれる
+        this.InitializeData();
         document.getElementById('button11').addEventListener("click", function (event) {
             document.getElementById('button12').click();
         });
@@ -91,54 +135,6 @@ export default {
             document.getElementById('button51').click();
         });
     },
-    methods: {
-        InitializeData() {
-            this.$store.dispatch('InitializeFireData').then( () => {
-                // this.$store.dispatch('getCategoryData')  
-                this.$store.dispatch('getTopData')
-                this.$store.dispatch('getFoodData')
-                this.$store.dispatch('getNewsData')
-                this.$store.dispatch('getSpaData')
-                this.$store.dispatch('getTourData')
-            }) 
-        },
-        doSearch() {
-            try{
-                // this.$router.push('/searchResult') <-これはただ、リンク変えるだけ
-                this.$router.push({ name: 'searchResult', params: { search: this.search_text } }) //<- これはリンク先に検索したのを渡すことができる
-                this.$store.dispatch('getSearchData', this.search_text)    //検索結果ページで使うデータ(search_fire_data)をstoreから参照 -> searchResult.vueのcomputedのfire_dataに反映
-                this.search_text = '' //検索バーに検索した文字を残さないための処理
-            } catch(e) {
-                console.log('error')
-                //エラーは無視（search_textに何も入力してない時怒られるから書いた）
-            }
-
-        },
-        deleteText() {
-            this.search_text = '' //検索バーに検索した文字を残さないための処理
-        }, 
-        // ページのトップに移動する関数
-        scrollTop() {
-            window.scrollTo({
-                top: 0,  //どこに移動するか
-                behavior: 'smooth'  //ここでどのように移動するか決める smoothでゆっくり移動する
-            });
-        },
-        // ボタンが現れる関数
-        scrollWindow() {
-            const top = 100 //topから100pxスクロールしたらボタン登場
-            this.scroll = window.scrollY //垂直方向
-            if (top <= this.scroll) {
-                this.buttonActive = true   //ボタン見えるようになる
-            } else {
-                this.buttonActive = false  //ボタン見えない
-            }
-        }
-    },
-    mounted() {
-        window.addEventListener('scroll', this.scrollWindow)   //スクロールすると関数が察知してくれる
-        this.InitializeData();
-    },
 }
 </script>
 
@@ -160,7 +156,6 @@ header {
     /* 固定した要素は浮いた状態になるので、横幅100%にする */
     height: 70px;
 }
-
 .header-inner {
     display: flex;
     height: 70px;
@@ -169,7 +164,6 @@ header {
     padding: 0 36px;
     margin: 0 auto;
 }
-
 .header-logoImg {
     display: block;
     /* 扱いやすいようにblock要素にする */
@@ -177,7 +171,6 @@ header {
     /* 横幅を任意の大きさに調整 */
     margin-top: 10px;
 }
-
 .searchArea {
     width: 350px;
     /* inputの幅           */
@@ -211,13 +204,11 @@ header {
     font-style: normal;
     text-align: center;
 }
-
 /*テキスト入力欄にフォーカスか来たとき*/
 .searchArea:focus {
     background-color: #e6f2ff;
     /* フォーカス時背景色  */
 }
-
 .header-inner2 {
     background-color: #ffffee;
     display: flex;
@@ -229,14 +220,12 @@ header {
     height: 60px;
     z-index: 1;
 }
-
 .header-nav {
     display: flex;
     padding: 0 36px;
     overflow-x: auto;
     white-space: nowrap;
 }
-
 .header-nav label {
     background: #FFFFFF;
     border: 1px solid #CCCCCC;
@@ -247,7 +236,6 @@ header {
     margin: 0 3px;
     /* ナビゲーションに左右のスペースを付ける */
 }
-
 .pageChange {
     display: block;
     /* 扱いやすいようにblock要素にする */
@@ -259,20 +247,16 @@ header {
     text-decoration-line: none;
     padding: 5px 15px;
 }
-
 .header-nav input:checked+ label {
     background: rgba(76, 197, 235, 0.25);
     border: 1px solid rgba(76, 197, 235, 0.25);
 }
-
 .header-nav input:checked+ label .pageChange {
     color: #4C79EB;
 }
-
 .header-nav input {
     display: none;
 }
-
 /* ページトップへ自動スクロールするボタンのスタイル */
 .button {
     position: fixed;
@@ -290,138 +274,56 @@ header {
     opacity: 0.7;
     /* ボタンにカーソルを合わせるとポインターになる */
 }
-
 /* アニメーション中のスタイル */
 .button-enter-active,
 .button-leave-active {
     transition: opacity 0.5s;
     /* 何秒かけて変わるのか */
 }
-
 /* 表示するアニメーション */
 .button-enter-from {
     opacity: 0;
 }
-
 .button-enter-to {
     opacity: 0.7;
 }
-
 /* 非表示にするアニメーション */
 .button-leave-from {
     opacity: 0.7;
 }
-
 .button-leave-to {
     opacity: 0;
 }
-
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
-
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
-    /* 任意のフォントサイズにする */
-    font-weight: bold;
-    /* 太字にする */
-    color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
-}
-
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
-}
-
-
 /* タブレット・スマートフォン用スタイル */
 @media(max-width: 971px) {
-    .header-nav {
-        padding-left: 0;
-    }
-
     /* .header-logoImg {
         width: 150px;
         margin-top: 10px;
     } */
-
     /* .searchArea {
     width: 225px;
     height: 30px;
     } */
 }
-
-
 /* スマートフォン用スタイル */
 @media(max-width: 647px) {
     .header-inner {
         padding: 0 5px;
     }
-
     .searchArea {
         width: 225px;
         height: 30px;
     }
-
     /* .header-inner {
         display: block;
         height: 35px;
     }
-
     .header-logoImg {
         margin: 0 auto;
     }
-
     .searchArea {
         display: none;
     } */
-
     .header-inner-smart {
         display: flex;
         height: 35px;
@@ -430,12 +332,10 @@ header {
         padding: 0 20px;
         margin: 0 auto;
     }
-
     .cancel {
         font-size: 250%;
         font-weight: bold;
     }
-
     .searchAreaSmart {
         width: 350px;
         /* inputの幅           */
@@ -465,7 +365,6 @@ header {
         outline: 0;
         /* 入力薄枠を非表示    */
     }
-
     /*テキスト入力欄にフォーカスか来たとき*/
     .searchAreaSmart:focus {
         background-color: #e6f2ff;

--- a/HaCollect/src/App.vue
+++ b/HaCollect/src/App.vue
@@ -9,13 +9,30 @@
             <!-- 検索バー -->
             <input type="text" v-model="input" v-on:keydown.enter="doSearch" class="searchArea" placeholder="キーワード検索">
         </div>
-        <!-- <div class="header-inner-smart"> -->
-            <!-- スマホキーボード用キャンセルボタン -->
-            <!-- <div class="cancel" v-on:click="deleteText">×</div> -->
-            <!-- スマホサイズ用検索バー -->
-            <!-- <input type="text" v-model="input" v-on:keydown.enter="doSearch" class="searchAreaSmart" -->
-                <!-- placeholder="キーワード検索"> -->
-        <!-- </div> -->
+        <div class="header-inner2">
+            <div class="header-nav">
+                <input type="radio" checked id="change1" name="header-navlist">
+                <label for="change1" id="button11">
+                    <router-link class="pageChange" id="button12" to="/">ホーム</router-link>
+                </label>
+                <input type="radio" id="change2" name="header-navlist">
+                <label for="change2" id="button21">
+                    <router-link class="pageChange" id="button22" to="/eat">ごはん</router-link>
+                </label>
+                <input type="radio" id="change3" name="header-navlist">
+                <label for="change3" id="button31">
+                    <router-link class="pageChange" id="button32" to="/spa">温泉</router-link>
+                </label>
+                <input type="radio" id="change4" name="header-navlist">
+                <label for="change4" id="button41">
+                    <router-link class="pageChange" id="button42" to="/tour">観光</router-link>
+                </label>
+                <input type="radio" id="change5" name="header-navlist">
+                <label for="change5" id="button51">
+                    <router-link class="pageChange" id="button52" to="/news">ニュース</router-link>
+                </label>
+            </div>
+        </div>
     </header>
 
     <!-- 現在のリンクごとに表示するコンポーネント -->
@@ -44,9 +61,41 @@ export default {
     },
     mounted() {
         window.addEventListener('scroll', this.scrollWindow)   //スクロールすると関数が察知してくれる
+        document.getElementById('button11').addEventListener("click", function (event) {
+            document.getElementById('button12').click();
+        });
+        document.getElementById('button12').addEventListener("click", function (event) {
+            document.getElementById('button11').click();
+        });
+        document.getElementById('button21').addEventListener("click", function (event) {
+            document.getElementById('button22').click();
+        });
+        document.getElementById('button22').addEventListener("click", function (event) {
+            document.getElementById('button21').click();
+        });
+        document.getElementById('button31').addEventListener("click", function (event) {
+            document.getElementById('button32').click();
+        });
+        document.getElementById('button32').addEventListener("click", function (event) {
+            document.getElementById('button31').click();
+        });
+        document.getElementById('button41').addEventListener("click", function (event) {
+            document.getElementById('button42').click();
+        });
+        document.getElementById('button42').addEventListener("click", function (event) {
+            document.getElementById('button41').click();
+        });
+        document.getElementById('button51').addEventListener("click", function (event) {
+            document.getElementById('button52').click();
+        });
+        document.getElementById('button52').addEventListener("click", function (event) {
+            document.getElementById('button51').click();
+        });
     },
+
     methods: {
         doSearch() {
+            console.log(this.input)
             this.search_text = this.input
             // this.$router.push('/searchResult') <-これはただ、リンク変えるだけ
             this.$router.push({ name: 'searchResult', params: { search: this.input } }) //<- これはリンク先に検索したのを渡すことができる
@@ -55,7 +104,7 @@ export default {
         deleteText() {
             this.search_text = this.input
             this.input = '' //検索バーに検索した文字を残さないための処理
-        }, 
+        },
         // ページのトップに移動する関数
         scrollTop() {
             window.scrollTo({
@@ -153,7 +202,58 @@ header {
     /* フォーカス時背景色  */
 }
 
-.header-inner-smart {
+.header-inner2 {
+    background-color: #ffffee;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin: 0 auto;
+    position: fixed;
+    height: 60px;
+    z-index: 1;
+}
+
+.header-nav {
+    display: flex;
+    padding: 0 36px;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.header-nav label {
+    background: #FFFFFF;
+    border: 1px solid #CCCCCC;
+    border-radius: 5px;
+    font-family: 'Inter';
+    font-style: normal;
+    width: 114px;
+    margin: 0 3px;
+    /* ナビゲーションに左右のスペースを付ける */
+}
+
+.pageChange {
+    display: block;
+    /* 扱いやすいようにblock要素にする */
+    font-size: 20px;
+    /* 任意のフォントサイズにする */
+    font-weight: bold;
+    /* 太字にする */
+    color: #000;
+    text-decoration-line: none;
+    padding: 5px 15px;
+}
+
+.header-nav input:checked+ label {
+    background: rgba(76, 197, 235, 0.25);
+    border: 1px solid rgba(76, 197, 235, 0.25);
+}
+
+.header-nav input:checked+ label .pageChange {
+    color: #4C79EB;
+}
+
+.header-nav input {
     display: none;
 }
 
@@ -222,8 +322,8 @@ header {
     }
 
     .searchArea {
-    width: 225px;
-    height: 30px;
+        width: 225px;
+        height: 30px;
     }
 
     /* .header-inner {

--- a/HaCollect/src/components/eatPage.vue
+++ b/HaCollect/src/components/eatPage.vue
@@ -1,25 +1,4 @@
 <template>
-    <div class="header-inner2">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <router-link to="/">ホーム</router-link>
-                </li>
-                <li>
-                    <router-link class="nowPage" to="/eat">ごはん</router-link>
-                </li>
-                <li>
-                    <router-link to="/spa">温泉</router-link>
-                </li>
-                <li>
-                    <router-link to="/tour">観光</router-link>
-                </li>
-                <li>
-                    <router-link to="/news">ニュース</router-link>
-                </li>
-            </ul>
-        </nav>
-    </div>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <div class="item">
@@ -139,68 +118,8 @@ export default {
 
 
 <style scoped>
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
-
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-    
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
-    /* 任意のフォントサイズにする */
-    font-weight: bold;
-    /* 太字にする */
-    color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
-}
-
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+.hello {
+    padding-top: 80px;
 }
 
 .infomation {
@@ -212,11 +131,6 @@ export default {
     display: flex;
     flex-wrap: wrap;
 }
-
-.hello {
-    padding-top: 80px;
-}
-
 
 .card_All {
     position: relative;
@@ -334,18 +248,6 @@ export default {
     .header-nav {
         padding-left: 0;
     }
-
-    /* .item {
-        謎
-        
-    } */
-
-}
-
-@media(max-width: 647px) {
-    /* .item {
-        謎
-    } */
 }
 
 @media(min-width: 750px) {
@@ -353,8 +255,5 @@ export default {
         border-left: 1px solid #aaaaaa;
         border-right: 1px solid #aaaaaa;
     }
-    /* .item {
-        謎
-    } */
 }
 </style>

--- a/HaCollect/src/components/newsPage.vue
+++ b/HaCollect/src/components/newsPage.vue
@@ -1,25 +1,4 @@
 <template>
-    <div class="header-inner2">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <router-link to="/">ホーム</router-link>
-                </li>
-                <li>
-                    <router-link to="/eat">ごはん</router-link>
-                </li>
-                <li>
-                    <router-link to="/spa">温泉</router-link>
-                </li>
-                <li>
-                    <router-link to="/tour">観光</router-link>
-                </li>
-                <li>
-                    <router-link class="nowPage" to="/news">ニュース</router-link>
-                </li>
-            </ul>
-        </nav>
-    </div>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <div class="item">
@@ -139,67 +118,8 @@ export default {
 
 
 <style scoped>
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
-
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
-    /* 任意のフォントサイズにする */
-    font-weight: bold;
-    /* 太字にする */
-    color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
-}
-
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+.hello {
+    padding-top: 80px;
 }
 
 .infomation {
@@ -211,11 +131,6 @@ export default {
     display: flex;
     flex-wrap: wrap;
 }
-
-.hello {
-    padding-top: 80px;
-}
-
 
 .card_All {
     position: relative;
@@ -333,18 +248,6 @@ export default {
     .header-nav {
         padding-left: 0;
     }
-
-    /* .item {
-        謎
-        
-    } */
-
-}
-
-@media(max-width: 647px) {
-    /* .item {
-        謎
-    } */
 }
 
 @media(min-width: 750px) {
@@ -352,8 +255,5 @@ export default {
         border-left: 1px solid #aaaaaa;
         border-right: 1px solid #aaaaaa;
     }
-    /* .item {
-        謎
-    } */
 }
 </style>

--- a/HaCollect/src/components/searchResult.vue
+++ b/HaCollect/src/components/searchResult.vue
@@ -1,33 +1,6 @@
 <template>
-    <div class="header-inner2">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <router-link to="/">ホーム</router-link>
-                </li>
-                <li>
-                    <router-link to="/eat">ごはん</router-link>
-                </li>
-                <li>
-                    <router-link to="/spa">温泉</router-link>
-                </li>
-                <li>
-                    <router-link to="/tour">観光</router-link>
-                </li>
-                <li>
-                    <router-link to="/news">ニュース</router-link>
-                </li>
-            </ul>
-        </nav>
-    </div>
     <div class="header-inner3">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <a class="searchWord"><span style="color: #4c9eeb;">{{ search }}</span>の検索結果</a>
-                </li>
-            </ul>
-        </nav>
+        <p class="searchWord">{{ search }}の検索結果</p>
     </div>
 
     <div class="hello">
@@ -107,7 +80,10 @@ const app = initializeApp(firebaseConfig);
 const database = getDatabase(app)
 
 export default {
-    name: "topPage",
+    name: "searchResult",
+    props: {
+        search: String
+    },
     data() {
         return {
             fire_data: null,  //firebaseのデータベースの中身を入れる変数
@@ -144,23 +120,12 @@ export default {
         this.getData()
     }
 };
+
 </script>
 
 
 
 <style scoped>
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
-
 .header-inner3 {
     background-color: #eeeeee;
     display: flex;
@@ -171,58 +136,20 @@ export default {
     position: fixed;
     height: 30px;
     margin-top: 60px;
+    z-index: 1;
 }
 
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
+.header-inner3 p {
     font-size: 20px;
     /* 任意のフォントサイズにする */
     font-weight: bold;
     /* 太字にする */
     color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
+    padding: 0 36px;
 }
 
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-    width: auto;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+.hello {
+    padding-top: 110px;
 }
 
 .infomation {
@@ -234,11 +161,6 @@ export default {
     display: flex;
     flex-wrap: wrap;
 }
-
-.hello {
-    padding-top: 80px;
-}
-
 
 .card_All {
     position: relative;
@@ -356,27 +278,12 @@ export default {
     .header-nav {
         padding-left: 0;
     }
-
-    /* .item {
-        謎
-        
-    } */
-
-}
-
-@media(max-width: 647px) {
-    /* .item {
-        謎
-    } */
 }
 
 @media(min-width: 750px) {
-    .card_All{
+    .card_All {
         border-left: 1px solid #aaaaaa;
         border-right: 1px solid #aaaaaa;
     }
-    /* .item {
-        謎
-    } */
 }
 </style>

--- a/HaCollect/src/components/spaPage.vue
+++ b/HaCollect/src/components/spaPage.vue
@@ -1,25 +1,4 @@
 <template>
-    <div class="header-inner2">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <router-link to="/">ホーム</router-link>
-                </li>
-                <li>
-                    <router-link to="/eat">ごはん</router-link>
-                </li>
-                <li>
-                    <router-link class="nowPage" to="/spa">温泉</router-link>
-                </li>
-                <li>
-                    <router-link to="/tour">観光</router-link>
-                </li>
-                <li>
-                    <router-link to="/news">ニュース</router-link>
-                </li>
-            </ul>
-        </nav>
-    </div>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <div class="item">
@@ -139,67 +118,9 @@ export default {
 
 
 <style scoped>
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
 
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
-    /* 任意のフォントサイズにする */
-    font-weight: bold;
-    /* 太字にする */
-    color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
-}
-
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+.hello {
+    padding-top: 80px;
 }
 
 .infomation {
@@ -211,11 +132,6 @@ export default {
     display: flex;
     flex-wrap: wrap;
 }
-
-.hello {
-    padding-top: 80px;
-}
-
 
 .card_All {
     position: relative;
@@ -333,18 +249,6 @@ export default {
     .header-nav {
         padding-left: 0;
     }
-
-    /* .item {
-        謎
-        
-    } */
-
-}
-
-@media(max-width: 647px) {
-    /* .item {
-        謎
-    } */
 }
 
 @media(min-width: 750px) {
@@ -352,9 +256,6 @@ export default {
         border-left: 1px solid #aaaaaa;
         border-right: 1px solid #aaaaaa;
     }
-    /* .item {
-        謎
-    } */
 }
 </style>
     

--- a/HaCollect/src/components/topPage.vue
+++ b/HaCollect/src/components/topPage.vue
@@ -1,25 +1,4 @@
 <template>
-    <div class="header-inner2">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <router-link class="nowPage" to="/">ホーム</router-link>
-                </li>
-                <li>
-                    <router-link to="/eat">ごはん</router-link>
-                </li>
-                <li>
-                    <router-link to="/spa">温泉</router-link>
-                </li>
-                <li>
-                    <router-link to="/tour">観光</router-link>
-                </li>
-                <li>
-                    <router-link to="/news">ニュース</router-link>
-                </li>
-            </ul>
-        </nav>
-    </div>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <div class="item">
@@ -139,67 +118,8 @@ export default {
 
 
 <style scoped>
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
-
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
-    /* 任意のフォントサイズにする */
-    font-weight: bold;
-    /* 太字にする */
-    color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
-}
-
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+.hello {
+    padding-top: 80px;
 }
 
 .infomation {
@@ -211,11 +131,6 @@ export default {
     display: flex;
     flex-wrap: wrap;
 }
-
-.hello {
-    padding-top: 80px;
-}
-
 
 .card_All {
     position: relative;
@@ -333,28 +248,13 @@ export default {
     .header-nav {
         padding-left: 0;
     }
-
-    /* .item {
-        謎
-        
-    } */
-
-}
-
-@media(max-width: 647px) {
-    /* .item {
-        謎
-    } */
 }
 
 @media(min-width: 750px) {
-    .card_All{
+    .card_All {
         border-left: 1px solid #aaaaaa;
         border-right: 1px solid #aaaaaa;
     }
-    /* .item {
-        謎
-    } */
 }
 </style>
     

--- a/HaCollect/src/components/tourPage.vue
+++ b/HaCollect/src/components/tourPage.vue
@@ -1,25 +1,4 @@
 <template>
-    <div class="header-inner2">
-        <nav class="header-nav">
-            <ul class="header-navList">
-                <li>
-                    <router-link to="/">ホーム</router-link>
-                </li>
-                <li>
-                    <router-link to="/eat">ごはん</router-link>
-                </li>
-                <li>
-                    <router-link to="/spa">温泉</router-link>
-                </li>
-                <li>
-                    <router-link class="nowPage" to="/tour">観光</router-link>
-                </li>
-                <li>
-                    <router-link to="/news">ニュース</router-link>
-                </li>
-            </ul>
-        </nav>
-    </div>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <div class="item">
@@ -139,67 +118,8 @@ export default {
 
 
 <style scoped>
-.header-inner2 {
-    background-color: #ffffee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-    position: fixed;
-    height: 60px;
-    z-index: 1;
-}
-
-.header-nav {
-    padding-left: 36px;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
-.header-navList {
-    display: flex;
-    align-items: center;
-    margin: 0 17px;
-}
-
-.header-navList li {
-    margin: 0 3px
-        /* ナビゲーションに左右のスペースを付ける */
-}
-
-.header-navList li a {
-    display: block;
-    /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
-    /* 任意のフォントサイズにする */
-    font-weight: bold;
-    /* 太字にする */
-    color: #000;
-    text-decoration-line: none;
-    padding: 5px 15px;
-    background: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 5px;
-    font-family: 'Inter';
-    font-style: normal;
-    width: 82px;
-}
-
-.header-navList .nowPage {
-    color: #4C79EB;
-    background: rgba(76, 197, 235, 0.25);
-    border: 1px solid rgba(76, 197, 235, 0.25);
-}
-
-.header-navList li .searchWord {
-    background: none;
-    border: none;
-}
-
-.header-navList li a:hover {
-    opacity: 0.8;
-    /* ホバーしたときに少し薄くなるようにアニメーションを付ける */
+.hello {
+    padding-top: 80px;
 }
 
 .infomation {
@@ -211,11 +131,6 @@ export default {
     display: flex;
     flex-wrap: wrap;
 }
-
-.hello {
-    padding-top: 80px;
-}
-
 
 .card_All {
     position: relative;
@@ -333,18 +248,6 @@ export default {
     .header-nav {
         padding-left: 0;
     }
-
-    /* .item {
-        謎
-        
-    } */
-
-}
-
-@media(max-width: 647px) {
-    /* .item {
-        謎
-    } */
 }
 
 @media(min-width: 750px) {
@@ -352,9 +255,5 @@ export default {
         border-left: 1px solid #aaaaaa;
         border-right: 1px solid #aaaaaa;
     }
-
-    /* .item {
-        謎
-    } */
 }
 </style>


### PR DESCRIPTION
# 対応するPBI
- https://app.zenhub.com/workspaces/-63039094a8f9171f93314018/issues/funswift/swift2022c/21

# 対応するTask
- https://app.zenhub.com/workspaces/-63039094a8f9171f93314018/issues/funswift/swift2022c/37

# 概要
カテゴリを選択する横スクロール部分を
各コンポーネントに記述→App.vueに統一して記述
に変更した。

# 変更点・追加点
- カテゴリボタンをApp.vueに統一して記述した。
- これによりスクロールの状態がページ遷移しても維持されるようになった。
- ボタンの色が変わらなくなってしまったため、そもそもの構造をnav,ul,liを使ったものからinput,labelを使ったものに変更した。

# スクリーンショットなど(あれば)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

# チェックリスト
- [x] 仕様と実際の実装はあっているか
- [x] 無意味なコードは無いか
- [x] 命名は適切か
- [x] コーディング規約を守っているか
- [x] その他気になる点が無いか
