### PR TITLE
Feature/#93/update

### DIFF
--- a/HaCollect/src/components/eatPage.vue
+++ b/HaCollect/src/components/eatPage.vue
@@ -2,7 +2,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <p>{{index}}</p>
+                <!-- <p>{{index}}</p>   確認用 -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -16,6 +16,7 @@
                                 </template>
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
@@ -38,6 +39,7 @@
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img

--- a/HaCollect/src/components/eatPage.vue
+++ b/HaCollect/src/components/eatPage.vue
@@ -1,52 +1,59 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <div class="item">
-                <!-- ツイッターの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Twitter'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                        <template v-if="item.media != null">
-                            <!-- メディア情報がある場合 -->
-                            <template v-for="(url) in item.media">
-                                <!-- メディアキーの中にあるurlを取り出す -->
-                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+            <template v-if="index < max">
+                <p>{{index}}</p>
+                <div class="item">
+                    <!-- ツイッターの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Twitter'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                            <template v-if="item.media != null">
+                                <!-- メディア情報がある場合 -->
+                                <template v-for="(url) in item.media">
+                                    <!-- メディアキーの中にあるurlを取り出す -->
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
                             </template>
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/TwitterIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/TwitterIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-                <!-- インスタグラムの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Instagram'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                        <template v-if="item.media_type == 'VIDEO'">
-                            <!-- メディアの種類が動画だったら... -->
-                            <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                        </template>
-                        <template v-else>
-                            <!-- メディアの種類が動画以外だったら... -->
-                            <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/InstagramIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                    </template>
+                    <!-- インスタグラムの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Instagram'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                            <template v-if="item.media_type == 'VIDEO'">
+                                <!-- メディアの種類が動画だったら... -->
+                                <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                            </template>
+                            <template v-else>
+                                <!-- メディアの種類が動画以外だったら... -->
+                                <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
+                            </template>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/InstagramIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </div>
+                    </template>
+                </div>
+            </template>
         </div>
+    </div>
+
+    <div>
+        <p  v-on:click="displayMore">more</p>
     </div>
 </template>
 
@@ -56,6 +63,16 @@
 <script>
 export default {
     name: "eatPage",
+    data() {
+        return {
+            max: 100
+        }
+    },
+    methods: {
+        displayMore() {
+            this.max += 100
+        }
+    },        
     computed: {
         fire_data: function () {
             return this.$store.state.food_fire_data

--- a/HaCollect/src/components/newsPage.vue
+++ b/HaCollect/src/components/newsPage.vue
@@ -2,7 +2,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <p>{{index}}</p>
+                <!-- <p>{{index}}</p>   確認用 -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -16,6 +16,7 @@
                                 </template>
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
@@ -38,6 +39,7 @@
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img

--- a/HaCollect/src/components/newsPage.vue
+++ b/HaCollect/src/components/newsPage.vue
@@ -1,52 +1,59 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <div class="item">
-                <!-- ツイッターの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Twitter'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                        <template v-if="item.media != null">
-                            <!-- メディア情報がある場合 -->
-                            <template v-for="(url) in item.media">
-                                <!-- メディアキーの中にあるurlを取り出す -->
-                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+            <template v-if="index < max">
+                <p>{{index}}</p>
+                <div class="item">
+                    <!-- ツイッターの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Twitter'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                            <template v-if="item.media != null">
+                                <!-- メディア情報がある場合 -->
+                                <template v-for="(url) in item.media">
+                                    <!-- メディアキーの中にあるurlを取り出す -->
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
                             </template>
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/TwitterIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/TwitterIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-                <!-- インスタグラムの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Instagram'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                        <template v-if="item.media_type == 'VIDEO'">
-                            <!-- メディアの種類が動画だったら... -->
-                            <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                        </template>
-                        <template v-else>
-                            <!-- メディアの種類が動画以外だったら... -->
-                            <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/InstagramIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                    </template>
+                    <!-- インスタグラムの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Instagram'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                            <template v-if="item.media_type == 'VIDEO'">
+                                <!-- メディアの種類が動画だったら... -->
+                                <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                            </template>
+                            <template v-else>
+                                <!-- メディアの種類が動画以外だったら... -->
+                                <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
+                            </template>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/InstagramIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </div>
+                    </template>
+                </div>
+            </template>
         </div>
+    </div>
+
+    <div>
+        <p  v-on:click="displayMore">more</p>
     </div>
 </template>
 
@@ -56,6 +63,16 @@
 <script>
 export default {
     name: "newsPage",
+    data() {
+        return {
+            max: 100
+        }
+    },
+    methods: {
+        displayMore() {
+            this.max += 100
+        }
+    },        
     computed: {
         fire_data: function () {
             return this.$store.state.news_fire_data

--- a/HaCollect/src/components/searchResult.vue
+++ b/HaCollect/src/components/searchResult.vue
@@ -5,51 +5,54 @@
 
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <div class="item">
-                <!-- ツイッターの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Twitter'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                        <template v-if="item.media != null">
-                            <!-- メディア情報がある場合 -->
-                            <template v-for="(url) in item.media">
-                                <!-- メディアキーの中にあるurlを取り出す -->
-                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+            <template v-if="index < max">
+                <p>{{index}}</p>
+                <div class="item">
+                    <!-- ツイッターの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Twitter'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                            <template v-if="item.media != null">
+                                <!-- メディア情報がある場合 -->
+                                <template v-for="(url) in item.media">
+                                    <!-- メディアキーの中にあるurlを取り出す -->
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
                             </template>
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/TwitterIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/TwitterIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-                <!-- インスタグラムの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Instagram'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                        <template v-if="item.media_type == 'VIDEO'">
-                            <!-- メディアの種類が動画だったら... -->
-                            <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                        </template>
-                        <template v-else>
-                            <!-- メディアの種類が動画以外だったら... -->
-                            <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/InstagramIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                    </template>
+                    <!-- インスタグラムの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Instagram'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                            <template v-if="item.media_type == 'VIDEO'">
+                                <!-- メディアの種類が動画だったら... -->
+                                <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                            </template>
+                            <template v-else>
+                                <!-- メディアの種類が動画以外だったら... -->
+                                <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
+                            </template>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/InstagramIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </div>
+                    </template>
+                </div>
+            </template>
         </div>
     </div>
 </template>
@@ -63,7 +66,17 @@ export default {
     name: "searchResult",
     props: {
         search: String
+    },    
+    data() {
+        return {
+            max: 100
+        }
     },
+    methods: {
+        displayMore() {
+            this.max += 100
+        }
+    },        
     computed: {
         fire_data: function () {
             return this.$store.state.search_fire_data

--- a/HaCollect/src/components/searchResult.vue
+++ b/HaCollect/src/components/searchResult.vue
@@ -6,7 +6,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <p>{{index}}</p>
+                <!-- <p>{{index}}</p>   確認用 -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -20,6 +20,7 @@
                                 </template>
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
@@ -42,6 +43,7 @@
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img

--- a/HaCollect/src/components/spaPage.vue
+++ b/HaCollect/src/components/spaPage.vue
@@ -2,7 +2,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <p>{{index}}</p>
+                <!-- <p>{{index}}</p>   確認用 -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -16,6 +16,7 @@
                                 </template>
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
@@ -38,6 +39,7 @@
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img

--- a/HaCollect/src/components/spaPage.vue
+++ b/HaCollect/src/components/spaPage.vue
@@ -1,52 +1,59 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <div class="item">
-                <!-- ツイッターの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Twitter'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                        <template v-if="item.media != null">
-                            <!-- メディア情報がある場合 -->
-                            <template v-for="(url) in item.media">
-                                <!-- メディアキーの中にあるurlを取り出す -->
-                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+            <template v-if="index < max">
+                <p>{{index}}</p>
+                <div class="item">
+                    <!-- ツイッターの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Twitter'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                            <template v-if="item.media != null">
+                                <!-- メディア情報がある場合 -->
+                                <template v-for="(url) in item.media">
+                                    <!-- メディアキーの中にあるurlを取り出す -->
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
                             </template>
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/TwitterIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/TwitterIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-                <!-- インスタグラムの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Instagram'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                        <template v-if="item.media_type == 'VIDEO'">
-                            <!-- メディアの種類が動画だったら... -->
-                            <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                        </template>
-                        <template v-else>
-                            <!-- メディアの種類が動画以外だったら... -->
-                            <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/InstagramIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                    </template>
+                    <!-- インスタグラムの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Instagram'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                            <template v-if="item.media_type == 'VIDEO'">
+                                <!-- メディアの種類が動画だったら... -->
+                                <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                            </template>
+                            <template v-else>
+                                <!-- メディアの種類が動画以外だったら... -->
+                                <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
+                            </template>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/InstagramIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </div>
+                    </template>
+                </div>
+            </template>
         </div>
+    </div>
+
+    <div>
+        <p  v-on:click="displayMore">more</p>
     </div>
 </template>
 
@@ -56,6 +63,16 @@
 <script>
 export default {
     name: "spaPage",
+    data() {
+        return {
+            max: 100
+        }
+    },
+    methods: {
+        displayMore() {
+            this.max += 100
+        }
+    },        
     computed: {
         fire_data: function () {
             return this.$store.state.spa_fire_data

--- a/HaCollect/src/components/topPage.vue
+++ b/HaCollect/src/components/topPage.vue
@@ -2,7 +2,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <p>{{index}}</p>
+                <!-- <p>{{index}}</p>   確認用 -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -16,6 +16,7 @@
                                 </template>
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
@@ -38,6 +39,7 @@
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img

--- a/HaCollect/src/components/topPage.vue
+++ b/HaCollect/src/components/topPage.vue
@@ -1,52 +1,59 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <div class="item">
-                <!-- ツイッターの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Twitter'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                        <template v-if="item.media != null">
-                            <!-- メディア情報がある場合 -->
-                            <template v-for="(url) in item.media">
-                                <!-- メディアキーの中にあるurlを取り出す -->
-                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+            <template v-if="index < max">
+                <p>{{index}}</p>
+                <div class="item">
+                    <!-- ツイッターの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Twitter'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                            <template v-if="item.media != null">
+                                <!-- メディア情報がある場合 -->
+                                <template v-for="(url) in item.media">
+                                    <!-- メディアキーの中にあるurlを取り出す -->
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
                             </template>
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/TwitterIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/TwitterIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-                <!-- インスタグラムの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Instagram'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                        <template v-if="item.media_type == 'VIDEO'">
-                            <!-- メディアの種類が動画だったら... -->
-                            <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                        </template>
-                        <template v-else>
-                            <!-- メディアの種類が動画以外だったら... -->
-                            <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/InstagramIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                    </template>
+                    <!-- インスタグラムの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Instagram'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                            <template v-if="item.media_type == 'VIDEO'">
+                                <!-- メディアの種類が動画だったら... -->
+                                <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                            </template>
+                            <template v-else>
+                                <!-- メディアの種類が動画以外だったら... -->
+                                <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
+                            </template>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/InstagramIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </div>
+                    </template>
+                </div>
+            </template>
         </div>
+    </div>
+
+    <div>
+        <p  v-on:click="displayMore">more</p>
     </div>
 </template>
 
@@ -56,6 +63,16 @@
 <script>
 export default {
     name: "topPage",
+    data() {
+        return {
+            max: 100
+        }
+    },
+    methods: {
+        displayMore() {
+            this.max += 100
+        }
+    },    
     computed: {
         fire_data: function () {
             return this.$store.state.top_fire_data   //store.jsのstateを参照

--- a/HaCollect/src/components/tourPage.vue
+++ b/HaCollect/src/components/tourPage.vue
@@ -2,7 +2,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <p>{{index}}</p>
+                <!-- <p>{{index}}</p>   確認用 -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -16,6 +16,7 @@
                                 </template>
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
@@ -38,6 +39,7 @@
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
                             <div class="ac-box">
+                                <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img

--- a/HaCollect/src/components/tourPage.vue
+++ b/HaCollect/src/components/tourPage.vue
@@ -1,52 +1,59 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <div class="item">
-                <!-- ツイッターの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Twitter'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                        <template v-if="item.media != null">
-                            <!-- メディア情報がある場合 -->
-                            <template v-for="(url) in item.media">
-                                <!-- メディアキーの中にあるurlを取り出す -->
-                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+            <template v-if="index < max">
+                <p>{{index}}</p>
+                <div class="item">
+                    <!-- ツイッターの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Twitter'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                            <template v-if="item.media != null">
+                                <!-- メディア情報がある場合 -->
+                                <template v-for="(url) in item.media">
+                                    <!-- メディアキーの中にあるurlを取り出す -->
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
                             </template>
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/TwitterIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/TwitterIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-                <!-- インスタグラムの投稿の表示 -->
-                <template v-if="item.SNS_type == 'Instagram'">
-                    <div class="card_All">
-                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                        <template v-if="item.media_type == 'VIDEO'">
-                            <!-- メディアの種類が動画だったら... -->
-                            <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                        </template>
-                        <template v-else>
-                            <!-- メディアの種類が動画以外だったら... -->
-                            <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                        </template>
-                        <div class="ac-box">
-                            <input :id="[index]" name="accordion-1" type="checkbox" />
-                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                    src="../assets/InstagramIcon.png" /></a>
-                            <!-- リンク -->
-                            <label :for="[index]"></label>
+                    </template>
+                    <!-- インスタグラムの投稿の表示 -->
+                    <template v-if="item.SNS_type == 'Instagram'">
+                        <div class="card_All">
+                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                            <template v-if="item.media_type == 'VIDEO'">
+                                <!-- メディアの種類が動画だったら... -->
+                                <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                            </template>
+                            <template v-else>
+                                <!-- メディアの種類が動画以外だったら... -->
+                                <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
+                            </template>
+                            <div class="ac-box">
+                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                        src="../assets/InstagramIcon.png" /></a>
+                                <!-- リンク -->
+                                <label :for="[index]"></label>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </div>
+                    </template>
+                </div>
+            </template>
         </div>
+    </div>
+
+    <div>
+        <p  v-on:click="displayMore">more</p>
     </div>
 </template>
 
@@ -56,6 +63,16 @@
 <script>
 export default {
     name: "tourPage",
+    data() {
+        return {
+            max: 100
+        }
+    },
+    methods: {
+        displayMore() {
+            this.max += 100
+        }
+    },        
     computed: {
         fire_data: function () {
             return this.$store.state.tour_fire_data

--- a/HaCollect/src/store.js
+++ b/HaCollect/src/store.js
@@ -65,7 +65,7 @@ export const store = createStore({
             
             return new Promise(function(resolve, reject) {
                 try {
-                    const que = query(ref(database, 'SNS_data/'), orderByChild('date'));  //SNS_dataを投稿日順に昇順でソートしたものをqueに格納する
+                    const que = query(ref(database, 'SNS_data/'), orderByChild('date'));  //SNS_dataを投稿日を秒数にしてマイナスをつけ、昇順でソートしたものをqueに格納する
 
                     get(que).then((snapshot) => {   //snapshot->データ全体  childSnapshot->データ一つ
         


### PR DESCRIPTION
# 対応するPBI
- #77 

# 対応するTask
- #93 

# 概要
選別精度を向上させる＆表示の順序の修正＆表示する投稿の制限を実装＆日付の表示

# 変更点・追加点
- 投稿の表示が日付の最新順になっていなかったので、pythonのコードでデータベースに格納する際、日付に-（マイナス）をつけて、それを昇順でとってくるようにした。結果、日付の最新順に表示することができた。
- 1000件取得してきたら、トップページはそのまま1000件表示してしまっていたので、最大100件表示するようにし、さらに表示させたい場合は、「moreボタン」を押すことでさらに100件表示できるようにした
- 投稿に日付の表示がされていなかったので、日付をとりあえず表示するようにした（表示形式がTwitterとInstagramでバラバラなのは許して）

# Pythonのコードについて
- 選別のルールに、「画像が含まれていたら取得」という条件を付け足した。（タイムラインとかでは、画像なしでリンクはある投稿が多く、本来、60件取ってきたら40件取得してくるところを、23件しか取得されないという事態が起こっている。なので、この条件には修正が必要かもしれない）
- 取得する際のクエリに、「-政権 -競馬」などを追加して除外するようにした。

# スクリーンショットなど(あれば)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

# チェックリスト
- [ ] 仕様と実際の実装はあっているか
- [ ] 無意味なコードは無いか
- [ ] 命名は適切か
- [ ] コーディング規約を守っているか
- [ ] その他気になる点が無いか
