### PR TITLE
feature/#96/video Twitterの動画を表示＆インスタフラムの複数メディアの場合の表示を実装

### DIFF
--- a/HaCollect/src/components/eatPage.vue
+++ b/HaCollect/src/components/eatPage.vue
@@ -1,35 +1,36 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
-                <div class="item">
-                    <!-- ツイッターの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Twitter'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">
-                                <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">
-                                    <!-- メディアキーの中にあるurlを取り出す -->
+            <div class="item">
+                <!-- ツイッターの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Twitter'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                        <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
+                            <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
+                                <template v-if="url.media_type == 'video'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
                                     <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
                                 </template>
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/TwitterIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/TwitterIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                    <!-- インスタグラムの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Instagram'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                    </div>
+                </template>
+                <!-- インスタグラムの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Instagram'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                        <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
                             <template v-if="item.media_type == 'VIDEO'">
                                 <!-- メディアの種類が動画だったら... -->
                                 <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
@@ -38,19 +39,28 @@
                                 <!-- メディアの種類が動画以外だったら... -->
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/InstagramIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <template v-else>
+                            <template v-for="(url) in item.media">
+                                <template v-if="url.media_type == 'VIDEO'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
+                            </template>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/InstagramIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                </div>
-            </template>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 

--- a/HaCollect/src/components/newsPage.vue
+++ b/HaCollect/src/components/newsPage.vue
@@ -1,35 +1,36 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
-                <div class="item">
-                    <!-- ツイッターの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Twitter'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">
-                                <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">
-                                    <!-- メディアキーの中にあるurlを取り出す -->
+            <div class="item">
+                <!-- ツイッターの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Twitter'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                        <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
+                            <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
+                                <template v-if="url.media_type == 'video'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
                                     <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
                                 </template>
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/TwitterIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/TwitterIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                    <!-- インスタグラムの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Instagram'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                    </div>
+                </template>
+                <!-- インスタグラムの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Instagram'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                        <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
                             <template v-if="item.media_type == 'VIDEO'">
                                 <!-- メディアの種類が動画だったら... -->
                                 <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
@@ -38,19 +39,28 @@
                                 <!-- メディアの種類が動画以外だったら... -->
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/InstagramIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <template v-else>
+                            <template v-for="(url) in item.media">
+                                <template v-if="url.media_type == 'VIDEO'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
+                            </template>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/InstagramIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                </div>
-            </template>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 

--- a/HaCollect/src/components/searchResult.vue
+++ b/HaCollect/src/components/searchResult.vue
@@ -2,38 +2,39 @@
     <div class="header-inner3">
         <p class="searchWord">{{ search }}の検索結果</p>
     </div>
-
+    
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
-                <div class="item">
-                    <!-- ツイッターの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Twitter'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">
-                                <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">
-                                    <!-- メディアキーの中にあるurlを取り出す -->
+            <div class="item">
+                <!-- ツイッターの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Twitter'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                        <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
+                            <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
+                                <template v-if="url.media_type == 'video'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
                                     <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
                                 </template>
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/TwitterIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/TwitterIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                    <!-- インスタグラムの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Instagram'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                    </div>
+                </template>
+                <!-- インスタグラムの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Instagram'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                        <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
                             <template v-if="item.media_type == 'VIDEO'">
                                 <!-- メディアの種類が動画だったら... -->
                                 <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
@@ -42,20 +43,33 @@
                                 <!-- メディアの種類が動画以外だったら... -->
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/InstagramIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <template v-else>
+                            <template v-for="(url) in item.media">
+                                <template v-if="url.media_type == 'VIDEO'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
+                            </template>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/InstagramIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                </div>
-            </template>
+                    </div>
+                </template>
+            </div>
         </div>
+    </div>
+
+    <div>
+        <p  v-on:click="displayMore">more</p>
     </div>
 </template>
 

--- a/HaCollect/src/components/spaPage.vue
+++ b/HaCollect/src/components/spaPage.vue
@@ -1,35 +1,36 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
-                <div class="item">
-                    <!-- ツイッターの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Twitter'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">
-                                <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">
-                                    <!-- メディアキーの中にあるurlを取り出す -->
+            <div class="item">
+                <!-- ツイッターの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Twitter'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                        <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
+                            <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
+                                <template v-if="url.media_type == 'video'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
                                     <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
                                 </template>
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/TwitterIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/TwitterIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                    <!-- インスタグラムの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Instagram'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                    </div>
+                </template>
+                <!-- インスタグラムの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Instagram'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                        <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
                             <template v-if="item.media_type == 'VIDEO'">
                                 <!-- メディアの種類が動画だったら... -->
                                 <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
@@ -38,19 +39,28 @@
                                 <!-- メディアの種類が動画以外だったら... -->
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/InstagramIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <template v-else>
+                            <template v-for="(url) in item.media">
+                                <template v-if="url.media_type == 'VIDEO'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
+                            </template>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/InstagramIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                </div>
-            </template>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 

--- a/HaCollect/src/components/topPage.vue
+++ b/HaCollect/src/components/topPage.vue
@@ -1,35 +1,36 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
-                <div class="item">
-                    <!-- ツイッターの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Twitter'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">
-                                <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">
-                                    <!-- メディアキーの中にあるurlを取り出す -->
+            <div class="item">
+                <!-- ツイッターの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Twitter'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                        <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
+                            <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
+                                <template v-if="url.media_type == 'video'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
                                     <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
                                 </template>
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/TwitterIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/TwitterIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                    <!-- インスタグラムの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Instagram'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                    </div>
+                </template>
+                <!-- インスタグラムの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Instagram'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                        <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
                             <template v-if="item.media_type == 'VIDEO'">
                                 <!-- メディアの種類が動画だったら... -->
                                 <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
@@ -38,19 +39,28 @@
                                 <!-- メディアの種類が動画以外だったら... -->
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/InstagramIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <template v-else>
+                            <template v-for="(url) in item.media">
+                                <template v-if="url.media_type == 'VIDEO'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
+                            </template>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/InstagramIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                </div>
-            </template>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 

--- a/HaCollect/src/components/tourPage.vue
+++ b/HaCollect/src/components/tourPage.vue
@@ -1,35 +1,36 @@
 <template>
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
-                <div class="item">
-                    <!-- ツイッターの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Twitter'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">
-                                <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">
-                                    <!-- メディアキーの中にあるurlを取り出す -->
+            <div class="item">
+                <!-- ツイッターの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Twitter'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
+                        <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
+                            <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
+                                <template v-if="url.media_type == 'video'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
                                     <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
                                 </template>
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/TwitterIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/TwitterIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                    <!-- インスタグラムの投稿の表示 -->
-                    <template v-if="item.SNS_type == 'Instagram'">
-                        <div class="card_All">
-                            <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                    </div>
+                </template>
+                <!-- インスタグラムの投稿の表示 -->
+                <template v-if="item.SNS_type == 'Instagram'">
+                    <div class="card_All">
+                        <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
+                        <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
                             <template v-if="item.media_type == 'VIDEO'">
                                 <!-- メディアの種類が動画だったら... -->
                                 <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
@@ -38,19 +39,28 @@
                                 <!-- メディアの種類が動画以外だったら... -->
                                 <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                             </template>
-                            <div class="ac-box">
-                                <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
-                                <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
-                                <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
-                                        src="../assets/InstagramIcon.png" /></a>
-                                <!-- リンク -->
-                                <label :for="[index]"></label>
-                            </div>
+                        </template>
+                        <template v-else>
+                            <template v-for="(url) in item.media">
+                                <template v-if="url.media_type == 'VIDEO'">
+                                    <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                </template>
+                                <template v-else>
+                                    <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                </template>
+                            </template>
+                        </template>
+                        <div class="ac-box">
+                            <input :id="[index]" name="accordion-1" type="checkbox" />
+                            <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
+                            <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
+                                    src="../assets/InstagramIcon.png" /></a>
+                            <!-- リンク -->
+                            <label :for="[index]"></label>
                         </div>
-                    </template>
-                </div>
-            </template>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
# 対応するPBI
- #77 

# 対応するTask
- #96 

# 概要
Twitterの動画を表示＆インスタフラムの複数メディアの場合の表示を実装

# 変更点・追加点
- Twitterの動画を今まで表示出来ていなかったので、表示できるようにした
- Instagramの複数メディアの投稿（画像2枚、画像＋動画、動画3枚などのパターン）は表示出来ていなかったので、表示できるようにした

**(Pythonのコードについて）**
- TwitterAPI.pyについて
https://stackoverflow.com/questions/66211050/twitter-api-v2-video-url このサイトを参考にPythonのコードを作成した

- InstagramAPI.pyについて
https://qiita.com/ricemountainer/items/70e96f14715633fb9966 このサイトを参考にPythonのコードを作成した

# スクリーンショットなど(あれば)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

# チェックリスト
- [ ] 仕様と実際の実装はあっているか
- [ ] 無意味なコードは無いか
- [ ] 命名は適切か
- [ ] コーディング規約を守っているか
- [ ] その他気になる点が無いか
