### PR TITLE
Feature/#99/slider

### DIFF
--- a/front/HaCollect/src/components/eatPage.vue
+++ b/front/HaCollect/src/components/eatPage.vue
@@ -1,35 +1,46 @@
 <template>
     <div class="hello">
+        <!-- 投稿の情報(fire_data)をitemの変数に格納    item: {TwitterとInstaでキーの数が違ったり、キーはたくさんあるからRealtime databaseで確認してくれ} -->
         <div class="infomation" v-for="(item, post_index) in fire_data">
+            <!-- 表示する投稿の数だけ表示（最初はmax=30件表示） -->
             <template v-if="post_index < max">
                 <!-- <p>{{post_index}}</p> -->
                 <div class="item">
+
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
                             <template v-if="item.media != null">  
+                                <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
                                 <template v-for="(url, url_name) in item.media">  
+                                    <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
                                     <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'video'">
+                                        <!-- 動画かどうかチェック -->
+                                        <template v-if="url.media_type == 'video'">    
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
+                                        <!-- 画像だったら以下実行 -->
                                         <template v-else>
                                             <img class="card_Image" v-bind:src=url.media_url> 
                                         </template>
                                     </template>
+                                </template>                            
+
+                                <!-- 画像スライダーのボタン(Twitter) -->
+                                <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>                
+                                <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->            
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
                             </template>
 
-                            <template v-if="page[post_index] > 0">
-                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                            </template>
-                            
-                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                            </template>
-
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -40,45 +51,57 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Twitter投稿の終わり -->
+
                     <!-- インスタグラムの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Instagram'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                            <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
-                                <template v-if="item.media_type == 'VIDEO'">
-                                    <!-- メディアの種類が動画だったら... -->
-                                    <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                                </template>
-                                <template v-else>
-                                    <!-- メディアの種類が動画以外だったら... -->
-                                    <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                                </template>
-                            </template>
-                            <template v-else>
-
-                                <template v-for="(url, url_name) in item.media">
-                                    <!-- <p>確認用</p> -->
-                                    <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'VIDEO'">
-                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                        </template>
-                                        <template v-else>
-                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
-                                        </template>
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
+                            <template v-if="item.media_type != null">
+                                <!-- その投稿が1枚の画像or動画のみだったら    CAROUSEL_ALBUM：複数メディアが含まれている状態  -->
+                                <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
+                                    <!-- そのメディアが動画だったら -->
+                                    <template v-if="item.media_type == 'VIDEO'">
+                                        <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                                    </template>
+                                    <!-- そのメディアが画像だったら -->
+                                    <template v-else>
+                                        <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                                     </template>
                                 </template>
-                                <template v-if="page[post_index] > 0">
-                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                                </template>
 
-                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                                </template>
+                                <!-- その投稿が複数メディアある投稿だったら  -->
+                                <template v-else>
+                                    <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
+                                    <template v-for="(url, url_name) in item.media">
+                                        <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
+                                        <template v-if="url_name == 'url' + page[post_index]">
+                                            <!-- 動画かどうかチェック -->
+                                            <template v-if="url.media_type == 'VIDEO'">
+                                                <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                            </template>
+                                            <!-- 画像だったら以下実行 -->
+                                            <template v-else>
+                                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                            </template>
+                                        </template>
+                                    </template>
 
-                                
+                                    <!-- 画像スライダーのボタン(Instagram) -->
+                                    <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->                                
+                                    <template v-if="page[post_index] > 0">
+                                        <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                    </template>
+                                    <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->   
+                                    <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                        <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                
                             </template>
 
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -89,13 +112,15 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Instagram投稿の終わり -->
+
                 </div>
             </template>
         </div>
     </div>
 
     <div>
+        <!-- 投稿表示限界数(fire_data.length)に達するまでmoreボタンを表示 -->
         <template v-if="max < fire_data.length">
             <!-- <p>{{max}}</p> -->
             <p  v-on:click="displayMore">more</p>
@@ -114,26 +139,31 @@ export default {
     name: "eatPage",
     data() {
         return {
-            max: posts_num,
-            page: this.InitializeArray(get_posts_num)
+            max: posts_num,  //表示する投稿数
+            page: this.InitializeArray(get_posts_num)   //urlの番号を格納する配列？
         }
     },
     methods: {
+        // 画像スライダーの一つ次の画像に移る関数
         nextPage(post_index){
             // console.log(post_index)
             this.page[post_index] ++;
         },
+        // 画像スライダーの一つ前の画像に移る関数
         prevPage(post_index){
             // console.log(post_index)
             this.page[post_index] --;
-        },        
+        },
+        // 投稿の表示数を増やす関数        
         displayMore() {
             this.max += posts_num
         },
+        // オブジェクトに含まれるキーの数を返す関数
         getObjLength (obj) {
-            // console.log(Object.keys(num).length)
+            // console.log(Object.keys(obj).length)
             return Object.keys(obj).length
         },
+        // 配列を作ってくれる関数
         InitializeArray(num) {
             let array = Array(num)
             array.fill(0)

--- a/front/HaCollect/src/components/eatPage.vue
+++ b/front/HaCollect/src/components/eatPage.vue
@@ -1,31 +1,43 @@
 <template>
     <div class="hello">
-        <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
+        <div class="infomation" v-for="(item, post_index) in fire_data">
+            <template v-if="post_index < max">
+                <!-- <p>{{post_index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
-                                    <template v-if="url.media_type == 'video'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                            <template v-if="item.media != null">  
+                                <template v-for="(url, url_name) in item.media">  
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'video'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> 
+                                        </template>
                                     </template>
                                 </template>
                             </template>
+
+                            <template v-if="page[post_index] > 0">
+                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                            </template>
+                            
+                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                            </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/TwitterIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -44,23 +56,37 @@
                                 </template>
                             </template>
                             <template v-else>
-                                <template v-for="(url) in item.media">
-                                    <template v-if="url.media_type == 'VIDEO'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                                <template v-for="(url, url_name) in item.media">
+                                    <!-- <p>確認用</p> -->
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'VIDEO'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                        </template>
                                     </template>
                                 </template>
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>
+
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                </template>
+
+                                
                             </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/InstagramIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -70,7 +96,10 @@
     </div>
 
     <div>
-        <p  v-on:click="displayMore">more</p>
+        <template v-if="max < fire_data.length">
+            <!-- <p>{{max}}</p> -->
+            <p  v-on:click="displayMore">more</p>
+        </template>
     </div>
 </template>
 
@@ -78,18 +107,40 @@
 
 
 <script>
+const posts_num = 30  //表示する投稿数
+const get_posts_num = 100  //取得してくる投稿数
+
 export default {
     name: "eatPage",
     data() {
         return {
-            max: 100
+            max: posts_num,
+            page: this.InitializeArray(get_posts_num)
         }
     },
     methods: {
+        nextPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] ++;
+        },
+        prevPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] --;
+        },        
         displayMore() {
-            this.max += 100
+            this.max += posts_num
+        },
+        getObjLength (obj) {
+            // console.log(Object.keys(num).length)
+            return Object.keys(obj).length
+        },
+        InitializeArray(num) {
+            let array = Array(num)
+            array.fill(0)
+            // console.log(array)
+            return array
         }
-    },        
+    },    
     computed: {
         fire_data: function () {
             return this.$store.state.food_fire_data

--- a/front/HaCollect/src/components/newsPage.vue
+++ b/front/HaCollect/src/components/newsPage.vue
@@ -1,31 +1,43 @@
 <template>
     <div class="hello">
-        <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
+        <div class="infomation" v-for="(item, post_index) in fire_data">
+            <template v-if="post_index < max">
+                <!-- <p>{{post_index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
-                                    <template v-if="url.media_type == 'video'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                            <template v-if="item.media != null">  
+                                <template v-for="(url, url_name) in item.media">  
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'video'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> 
+                                        </template>
                                     </template>
                                 </template>
                             </template>
+
+                            <template v-if="page[post_index] > 0">
+                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                            </template>
+                            
+                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                            </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/TwitterIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -44,23 +56,37 @@
                                 </template>
                             </template>
                             <template v-else>
-                                <template v-for="(url) in item.media">
-                                    <template v-if="url.media_type == 'VIDEO'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                                <template v-for="(url, url_name) in item.media">
+                                    <!-- <p>確認用</p> -->
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'VIDEO'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                        </template>
                                     </template>
                                 </template>
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>
+
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                </template>
+
+                                
                             </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/InstagramIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -70,7 +96,10 @@
     </div>
 
     <div>
-        <p  v-on:click="displayMore">more</p>
+        <template v-if="max < fire_data.length">
+            <!-- <p>{{max}}</p> -->
+            <p  v-on:click="displayMore">more</p>
+        </template>
     </div>
 </template>
 
@@ -78,18 +107,40 @@
 
 
 <script>
+const posts_num = 30  //表示する投稿数
+const get_posts_num = 100  //取得してくる投稿数
+
 export default {
     name: "newsPage",
     data() {
         return {
-            max: 100
+            max: posts_num,
+            page: this.InitializeArray(get_posts_num)
         }
     },
     methods: {
+        nextPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] ++;
+        },
+        prevPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] --;
+        },        
         displayMore() {
-            this.max += 100
+            this.max += posts_num
+        },
+        getObjLength (obj) {
+            // console.log(Object.keys(num).length)
+            return Object.keys(obj).length
+        },
+        InitializeArray(num) {
+            let array = Array(num)
+            array.fill(0)
+            // console.log(array)
+            return array
         }
-    },        
+    },    
     computed: {
         fire_data: function () {
             return this.$store.state.news_fire_data

--- a/front/HaCollect/src/components/newsPage.vue
+++ b/front/HaCollect/src/components/newsPage.vue
@@ -1,35 +1,46 @@
 <template>
     <div class="hello">
+        <!-- 投稿の情報(fire_data)をitemの変数に格納    item: {TwitterとInstaでキーの数が違ったり、キーはたくさんあるからRealtime databaseで確認してくれ} -->
         <div class="infomation" v-for="(item, post_index) in fire_data">
+            <!-- 表示する投稿の数だけ表示（最初はmax=30件表示） -->
             <template v-if="post_index < max">
                 <!-- <p>{{post_index}}</p> -->
                 <div class="item">
+
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
                             <template v-if="item.media != null">  
+                                <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
                                 <template v-for="(url, url_name) in item.media">  
+                                    <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
                                     <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'video'">
+                                        <!-- 動画かどうかチェック -->
+                                        <template v-if="url.media_type == 'video'">    
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
+                                        <!-- 画像だったら以下実行 -->
                                         <template v-else>
                                             <img class="card_Image" v-bind:src=url.media_url> 
                                         </template>
                                     </template>
+                                </template>                            
+
+                                <!-- 画像スライダーのボタン(Twitter) -->
+                                <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>                
+                                <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->            
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
                             </template>
 
-                            <template v-if="page[post_index] > 0">
-                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                            </template>
-                            
-                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                            </template>
-
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -40,45 +51,57 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Twitter投稿の終わり -->
+
                     <!-- インスタグラムの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Instagram'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                            <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
-                                <template v-if="item.media_type == 'VIDEO'">
-                                    <!-- メディアの種類が動画だったら... -->
-                                    <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                                </template>
-                                <template v-else>
-                                    <!-- メディアの種類が動画以外だったら... -->
-                                    <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                                </template>
-                            </template>
-                            <template v-else>
-
-                                <template v-for="(url, url_name) in item.media">
-                                    <!-- <p>確認用</p> -->
-                                    <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'VIDEO'">
-                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                        </template>
-                                        <template v-else>
-                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
-                                        </template>
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
+                            <template v-if="item.media_type != null">
+                                <!-- その投稿が1枚の画像or動画のみだったら    CAROUSEL_ALBUM：複数メディアが含まれている状態  -->
+                                <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
+                                    <!-- そのメディアが動画だったら -->
+                                    <template v-if="item.media_type == 'VIDEO'">
+                                        <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                                    </template>
+                                    <!-- そのメディアが画像だったら -->
+                                    <template v-else>
+                                        <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                                     </template>
                                 </template>
-                                <template v-if="page[post_index] > 0">
-                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                                </template>
 
-                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                                </template>
+                                <!-- その投稿が複数メディアある投稿だったら  -->
+                                <template v-else>
+                                    <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
+                                    <template v-for="(url, url_name) in item.media">
+                                        <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
+                                        <template v-if="url_name == 'url' + page[post_index]">
+                                            <!-- 動画かどうかチェック -->
+                                            <template v-if="url.media_type == 'VIDEO'">
+                                                <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                            </template>
+                                            <!-- 画像だったら以下実行 -->
+                                            <template v-else>
+                                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                            </template>
+                                        </template>
+                                    </template>
 
-                                
+                                    <!-- 画像スライダーのボタン(Instagram) -->
+                                    <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->                                
+                                    <template v-if="page[post_index] > 0">
+                                        <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                    </template>
+                                    <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->   
+                                    <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                        <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                
                             </template>
 
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -89,13 +112,15 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Instagram投稿の終わり -->
+
                 </div>
             </template>
         </div>
     </div>
 
     <div>
+        <!-- 投稿表示限界数(fire_data.length)に達するまでmoreボタンを表示 -->
         <template v-if="max < fire_data.length">
             <!-- <p>{{max}}</p> -->
             <p  v-on:click="displayMore">more</p>
@@ -114,26 +139,31 @@ export default {
     name: "newsPage",
     data() {
         return {
-            max: posts_num,
-            page: this.InitializeArray(get_posts_num)
+            max: posts_num,  //表示する投稿数
+            page: this.InitializeArray(get_posts_num)   //urlの番号を格納する配列？
         }
     },
     methods: {
+        // 画像スライダーの一つ次の画像に移る関数
         nextPage(post_index){
             // console.log(post_index)
             this.page[post_index] ++;
         },
+        // 画像スライダーの一つ前の画像に移る関数
         prevPage(post_index){
             // console.log(post_index)
             this.page[post_index] --;
-        },        
+        },
+        // 投稿の表示数を増やす関数        
         displayMore() {
             this.max += posts_num
         },
+        // オブジェクトに含まれるキーの数を返す関数
         getObjLength (obj) {
-            // console.log(Object.keys(num).length)
+            // console.log(Object.keys(obj).length)
             return Object.keys(obj).length
         },
+        // 配列を作ってくれる関数
         InitializeArray(num) {
             let array = Array(num)
             array.fill(0)

--- a/front/HaCollect/src/components/searchResult.vue
+++ b/front/HaCollect/src/components/searchResult.vue
@@ -4,36 +4,47 @@
     </div>
     
     <div class="hello">
+        <!-- 投稿の情報(fire_data)をitemの変数に格納    item: {TwitterとInstaでキーの数が違ったり、キーはたくさんあるからRealtime databaseで確認してくれ} -->
         <div class="infomation" v-for="(item, post_index) in fire_data">
+            <!-- 表示する投稿の数だけ表示（最初はmax=30件表示） -->
             <template v-if="post_index < max">
                 <!-- <p>{{post_index}}</p> -->
                 <div class="item">
+
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
                             <template v-if="item.media != null">  
+                                <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
                                 <template v-for="(url, url_name) in item.media">  
+                                    <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
                                     <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'video'">
+                                        <!-- 動画かどうかチェック -->
+                                        <template v-if="url.media_type == 'video'">    
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
+                                        <!-- 画像だったら以下実行 -->
                                         <template v-else>
                                             <img class="card_Image" v-bind:src=url.media_url> 
                                         </template>
                                     </template>
+                                </template>                            
+
+                                <!-- 画像スライダーのボタン(Twitter) -->
+                                <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>                
+                                <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->            
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
                             </template>
 
-                            <template v-if="page[post_index] > 0">
-                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                            </template>
-                            
-                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                            </template>
-
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -44,45 +55,57 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Twitter投稿の終わり -->
+
                     <!-- インスタグラムの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Instagram'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                            <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
-                                <template v-if="item.media_type == 'VIDEO'">
-                                    <!-- メディアの種類が動画だったら... -->
-                                    <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                                </template>
-                                <template v-else>
-                                    <!-- メディアの種類が動画以外だったら... -->
-                                    <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                                </template>
-                            </template>
-                            <template v-else>
-
-                                <template v-for="(url, url_name) in item.media">
-                                    <!-- <p>確認用</p> -->
-                                    <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'VIDEO'">
-                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                        </template>
-                                        <template v-else>
-                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
-                                        </template>
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
+                            <template v-if="item.media_type != null">
+                                <!-- その投稿が1枚の画像or動画のみだったら    CAROUSEL_ALBUM：複数メディアが含まれている状態  -->
+                                <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
+                                    <!-- そのメディアが動画だったら -->
+                                    <template v-if="item.media_type == 'VIDEO'">
+                                        <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                                    </template>
+                                    <!-- そのメディアが画像だったら -->
+                                    <template v-else>
+                                        <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                                     </template>
                                 </template>
-                                <template v-if="page[post_index] > 0">
-                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                                </template>
 
-                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                                </template>
+                                <!-- その投稿が複数メディアある投稿だったら  -->
+                                <template v-else>
+                                    <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
+                                    <template v-for="(url, url_name) in item.media">
+                                        <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
+                                        <template v-if="url_name == 'url' + page[post_index]">
+                                            <!-- 動画かどうかチェック -->
+                                            <template v-if="url.media_type == 'VIDEO'">
+                                                <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                            </template>
+                                            <!-- 画像だったら以下実行 -->
+                                            <template v-else>
+                                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                            </template>
+                                        </template>
+                                    </template>
 
-                                
+                                    <!-- 画像スライダーのボタン(Instagram) -->
+                                    <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->                                
+                                    <template v-if="page[post_index] > 0">
+                                        <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                    </template>
+                                    <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->   
+                                    <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                        <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                
                             </template>
 
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -93,7 +116,8 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Instagram投稿の終わり -->
+
                 </div>
             </template>
         </div>
@@ -121,26 +145,31 @@ export default {
     },    
     data() {
         return {
-            max: posts_num,
-            page: this.InitializeArray(get_posts_num)
+            max: posts_num,  //表示する投稿数
+            page: this.InitializeArray(get_posts_num)   //urlの番号を格納する配列？
         }
     },
     methods: {
+        // 画像スライダーの一つ次の画像に移る関数
         nextPage(post_index){
             // console.log(post_index)
             this.page[post_index] ++;
         },
+        // 画像スライダーの一つ前の画像に移る関数
         prevPage(post_index){
             // console.log(post_index)
             this.page[post_index] --;
-        },        
+        },
+        // 投稿の表示数を増やす関数        
         displayMore() {
             this.max += posts_num
         },
+        // オブジェクトに含まれるキーの数を返す関数
         getObjLength (obj) {
-            // console.log(Object.keys(num).length)
+            // console.log(Object.keys(obj).length)
             return Object.keys(obj).length
         },
+        // 配列を作ってくれる関数
         InitializeArray(num) {
             let array = Array(num)
             array.fill(0)

--- a/front/HaCollect/src/components/searchResult.vue
+++ b/front/HaCollect/src/components/searchResult.vue
@@ -4,32 +4,44 @@
     </div>
     
     <div class="hello">
-        <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
+        <div class="infomation" v-for="(item, post_index) in fire_data">
+            <template v-if="post_index < max">
+                <!-- <p>{{post_index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
-                                    <template v-if="url.media_type == 'video'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                            <template v-if="item.media != null">  
+                                <template v-for="(url, url_name) in item.media">  
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'video'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> 
+                                        </template>
                                     </template>
                                 </template>
                             </template>
+
+                            <template v-if="page[post_index] > 0">
+                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                            </template>
+                            
+                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                            </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/TwitterIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -48,23 +60,37 @@
                                 </template>
                             </template>
                             <template v-else>
-                                <template v-for="(url) in item.media">
-                                    <template v-if="url.media_type == 'VIDEO'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                                <template v-for="(url, url_name) in item.media">
+                                    <!-- <p>確認用</p> -->
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'VIDEO'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                        </template>
                                     </template>
                                 </template>
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>
+
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                </template>
+
+                                
                             </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/InstagramIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -74,7 +100,10 @@
     </div>
 
     <div>
-        <p  v-on:click="displayMore">more</p>
+        <template v-if="max < fire_data.length">
+            <!-- <p>{{max}}</p> -->
+            <p  v-on:click="displayMore">more</p>
+        </template>
     </div>
 </template>
 
@@ -82,6 +111,8 @@
 
 
 <script>
+const posts_num = 30  //表示する投稿数
+const get_posts_num = 100  //取得してくる投稿数
 
 export default {
     name: "searchResult",
@@ -90,14 +121,33 @@ export default {
     },    
     data() {
         return {
-            max: 100
+            max: posts_num,
+            page: this.InitializeArray(get_posts_num)
         }
     },
     methods: {
+        nextPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] ++;
+        },
+        prevPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] --;
+        },        
         displayMore() {
-            this.max += 100
+            this.max += posts_num
+        },
+        getObjLength (obj) {
+            // console.log(Object.keys(num).length)
+            return Object.keys(obj).length
+        },
+        InitializeArray(num) {
+            let array = Array(num)
+            array.fill(0)
+            // console.log(array)
+            return array
         }
-    },        
+    },    
     computed: {
         fire_data: function () {
             return this.$store.state.search_fire_data

--- a/front/HaCollect/src/components/spaPage.vue
+++ b/front/HaCollect/src/components/spaPage.vue
@@ -1,31 +1,43 @@
 <template>
     <div class="hello">
-        <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
+        <div class="infomation" v-for="(item, post_index) in fire_data">
+            <template v-if="post_index < max">
+                <!-- <p>{{post_index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
-                                    <template v-if="url.media_type == 'video'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                            <template v-if="item.media != null">  
+                                <template v-for="(url, url_name) in item.media">  
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'video'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> 
+                                        </template>
                                     </template>
                                 </template>
                             </template>
+
+                            <template v-if="page[post_index] > 0">
+                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                            </template>
+                            
+                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                            </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/TwitterIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -44,23 +56,37 @@
                                 </template>
                             </template>
                             <template v-else>
-                                <template v-for="(url) in item.media">
-                                    <template v-if="url.media_type == 'VIDEO'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                                <template v-for="(url, url_name) in item.media">
+                                    <!-- <p>確認用</p> -->
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'VIDEO'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                        </template>
                                     </template>
                                 </template>
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>
+
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                </template>
+
+                                
                             </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/InstagramIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -70,7 +96,10 @@
     </div>
 
     <div>
-        <p  v-on:click="displayMore">more</p>
+        <template v-if="max < fire_data.length">
+            <!-- <p>{{max}}</p> -->
+            <p  v-on:click="displayMore">more</p>
+        </template>
     </div>
 </template>
 
@@ -78,18 +107,40 @@
 
 
 <script>
+const posts_num = 30  //表示する投稿数
+const get_posts_num = 100  //取得してくる投稿数
+
 export default {
     name: "spaPage",
     data() {
         return {
-            max: 100
+            max: posts_num,
+            page: this.InitializeArray(get_posts_num)
         }
     },
     methods: {
+        nextPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] ++;
+        },
+        prevPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] --;
+        },        
         displayMore() {
-            this.max += 100
+            this.max += posts_num
+        },
+        getObjLength (obj) {
+            // console.log(Object.keys(num).length)
+            return Object.keys(obj).length
+        },
+        InitializeArray(num) {
+            let array = Array(num)
+            array.fill(0)
+            // console.log(array)
+            return array
         }
-    },        
+    },    
     computed: {
         fire_data: function () {
             return this.$store.state.spa_fire_data

--- a/front/HaCollect/src/components/spaPage.vue
+++ b/front/HaCollect/src/components/spaPage.vue
@@ -1,35 +1,46 @@
 <template>
     <div class="hello">
+        <!-- 投稿の情報(fire_data)をitemの変数に格納    item: {TwitterとInstaでキーの数が違ったり、キーはたくさんあるからRealtime databaseで確認してくれ} -->
         <div class="infomation" v-for="(item, post_index) in fire_data">
+            <!-- 表示する投稿の数だけ表示（最初はmax=30件表示） -->
             <template v-if="post_index < max">
                 <!-- <p>{{post_index}}</p> -->
                 <div class="item">
+
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
                             <template v-if="item.media != null">  
+                                <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
                                 <template v-for="(url, url_name) in item.media">  
+                                    <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
                                     <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'video'">
+                                        <!-- 動画かどうかチェック -->
+                                        <template v-if="url.media_type == 'video'">    
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
+                                        <!-- 画像だったら以下実行 -->
                                         <template v-else>
                                             <img class="card_Image" v-bind:src=url.media_url> 
                                         </template>
                                     </template>
+                                </template>                            
+
+                                <!-- 画像スライダーのボタン(Twitter) -->
+                                <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>                
+                                <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->            
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
                             </template>
 
-                            <template v-if="page[post_index] > 0">
-                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                            </template>
-                            
-                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                            </template>
-
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -40,45 +51,57 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Twitter投稿の終わり -->
+
                     <!-- インスタグラムの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Instagram'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                            <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
-                                <template v-if="item.media_type == 'VIDEO'">
-                                    <!-- メディアの種類が動画だったら... -->
-                                    <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                                </template>
-                                <template v-else>
-                                    <!-- メディアの種類が動画以外だったら... -->
-                                    <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                                </template>
-                            </template>
-                            <template v-else>
-
-                                <template v-for="(url, url_name) in item.media">
-                                    <!-- <p>確認用</p> -->
-                                    <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'VIDEO'">
-                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                        </template>
-                                        <template v-else>
-                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
-                                        </template>
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
+                            <template v-if="item.media_type != null">
+                                <!-- その投稿が1枚の画像or動画のみだったら    CAROUSEL_ALBUM：複数メディアが含まれている状態  -->
+                                <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
+                                    <!-- そのメディアが動画だったら -->
+                                    <template v-if="item.media_type == 'VIDEO'">
+                                        <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                                    </template>
+                                    <!-- そのメディアが画像だったら -->
+                                    <template v-else>
+                                        <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                                     </template>
                                 </template>
-                                <template v-if="page[post_index] > 0">
-                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                                </template>
 
-                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                                </template>
+                                <!-- その投稿が複数メディアある投稿だったら  -->
+                                <template v-else>
+                                    <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
+                                    <template v-for="(url, url_name) in item.media">
+                                        <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
+                                        <template v-if="url_name == 'url' + page[post_index]">
+                                            <!-- 動画かどうかチェック -->
+                                            <template v-if="url.media_type == 'VIDEO'">
+                                                <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                            </template>
+                                            <!-- 画像だったら以下実行 -->
+                                            <template v-else>
+                                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                            </template>
+                                        </template>
+                                    </template>
 
-                                
+                                    <!-- 画像スライダーのボタン(Instagram) -->
+                                    <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->                                
+                                    <template v-if="page[post_index] > 0">
+                                        <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                    </template>
+                                    <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->   
+                                    <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                        <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                
                             </template>
 
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -89,13 +112,15 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Instagram投稿の終わり -->
+
                 </div>
             </template>
         </div>
     </div>
 
     <div>
+        <!-- 投稿表示限界数(fire_data.length)に達するまでmoreボタンを表示 -->
         <template v-if="max < fire_data.length">
             <!-- <p>{{max}}</p> -->
             <p  v-on:click="displayMore">more</p>
@@ -114,26 +139,31 @@ export default {
     name: "spaPage",
     data() {
         return {
-            max: posts_num,
-            page: this.InitializeArray(get_posts_num)
+            max: posts_num,  //表示する投稿数
+            page: this.InitializeArray(get_posts_num)   //urlの番号を格納する配列？
         }
     },
     methods: {
+        // 画像スライダーの一つ次の画像に移る関数
         nextPage(post_index){
             // console.log(post_index)
             this.page[post_index] ++;
         },
+        // 画像スライダーの一つ前の画像に移る関数
         prevPage(post_index){
             // console.log(post_index)
             this.page[post_index] --;
-        },        
+        },
+        // 投稿の表示数を増やす関数        
         displayMore() {
             this.max += posts_num
         },
+        // オブジェクトに含まれるキーの数を返す関数
         getObjLength (obj) {
-            // console.log(Object.keys(num).length)
+            // console.log(Object.keys(obj).length)
             return Object.keys(obj).length
         },
+        // 配列を作ってくれる関数
         InitializeArray(num) {
             let array = Array(num)
             array.fill(0)

--- a/front/HaCollect/src/components/topPage.vue
+++ b/front/HaCollect/src/components/topPage.vue
@@ -1,35 +1,46 @@
 <template>
     <div class="hello">
+        <!-- 投稿の情報(fire_data)をitemの変数に格納    item: {TwitterとInstaでキーの数が違ったり、キーはたくさんあるからRealtime databaseで確認してくれ} -->
         <div class="infomation" v-for="(item, post_index) in fire_data">
+            <!-- 表示する投稿の数だけ表示（最初はmax=30件表示） -->
             <template v-if="post_index < max">
                 <!-- <p>{{post_index}}</p> -->
                 <div class="item">
+
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
                             <template v-if="item.media != null">  
+                                <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
                                 <template v-for="(url, url_name) in item.media">  
+                                    <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
                                     <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'video'">
+                                        <!-- 動画かどうかチェック -->
+                                        <template v-if="url.media_type == 'video'">    
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
+                                        <!-- 画像だったら以下実行 -->
                                         <template v-else>
                                             <img class="card_Image" v-bind:src=url.media_url> 
                                         </template>
                                     </template>
+                                </template>                            
+
+                                <!-- 画像スライダーのボタン(Twitter) -->
+                                <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>                
+                                <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->            
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
                             </template>
 
-                            <template v-if="page[post_index] > 0">
-                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                            </template>
-                            
-                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                            </template>
-
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -40,45 +51,57 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Twitter投稿の終わり -->
+
                     <!-- インスタグラムの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Instagram'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                            <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
-                                <template v-if="item.media_type == 'VIDEO'">
-                                    <!-- メディアの種類が動画だったら... -->
-                                    <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                                </template>
-                                <template v-else>
-                                    <!-- メディアの種類が動画以外だったら... -->
-                                    <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                                </template>
-                            </template>
-                            <template v-else>
-
-                                <template v-for="(url, url_name) in item.media">
-                                    <!-- <p>確認用</p> -->
-                                    <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'VIDEO'">
-                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                        </template>
-                                        <template v-else>
-                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
-                                        </template>
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
+                            <template v-if="item.media_type != null">
+                                <!-- その投稿が1枚の画像or動画のみだったら    CAROUSEL_ALBUM：複数メディアが含まれている状態  -->
+                                <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
+                                    <!-- そのメディアが動画だったら -->
+                                    <template v-if="item.media_type == 'VIDEO'">
+                                        <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                                    </template>
+                                    <!-- そのメディアが画像だったら -->
+                                    <template v-else>
+                                        <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                                     </template>
                                 </template>
-                                <template v-if="page[post_index] > 0">
-                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                                </template>
 
-                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                                </template>
+                                <!-- その投稿が複数メディアある投稿だったら  -->
+                                <template v-else>
+                                    <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
+                                    <template v-for="(url, url_name) in item.media">
+                                        <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
+                                        <template v-if="url_name == 'url' + page[post_index]">
+                                            <!-- 動画かどうかチェック -->
+                                            <template v-if="url.media_type == 'VIDEO'">
+                                                <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                            </template>
+                                            <!-- 画像だったら以下実行 -->
+                                            <template v-else>
+                                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                            </template>
+                                        </template>
+                                    </template>
 
-                                
+                                    <!-- 画像スライダーのボタン(Instagram) -->
+                                    <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->                                
+                                    <template v-if="page[post_index] > 0">
+                                        <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                    </template>
+                                    <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->   
+                                    <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                        <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                
                             </template>
 
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -89,13 +112,15 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Instagram投稿の終わり -->
+
                 </div>
             </template>
         </div>
     </div>
 
     <div>
+        <!-- 投稿表示限界数(fire_data.length)に達するまでmoreボタンを表示 -->
         <template v-if="max < fire_data.length">
             <!-- <p>{{max}}</p> -->
             <p  v-on:click="displayMore">more</p>
@@ -113,26 +138,31 @@ export default {
     name: "topPage",
     data() {
         return {
-            max: posts_num,
-            page: this.InitializeArray(get_posts_num)
+            max: posts_num,  //表示する投稿数
+            page: this.InitializeArray(get_posts_num)   //urlの番号を格納する配列？
         }
     },
     methods: {
+        // 画像スライダーの一つ次の画像に移る関数
         nextPage(post_index){
             // console.log(post_index)
             this.page[post_index] ++;
         },
+        // 画像スライダーの一つ前の画像に移る関数
         prevPage(post_index){
             // console.log(post_index)
             this.page[post_index] --;
-        },        
+        },
+        // 投稿の表示数を増やす関数        
         displayMore() {
             this.max += posts_num
         },
+        // オブジェクトに含まれるキーの数を返す関数
         getObjLength (obj) {
-            // console.log(Object.keys(num).length)
+            // console.log(Object.keys(obj).length)
             return Object.keys(obj).length
         },
+        // 配列を作ってくれる関数
         InitializeArray(num) {
             let array = Array(num)
             array.fill(0)

--- a/front/HaCollect/src/components/topPage.vue
+++ b/front/HaCollect/src/components/topPage.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="hello">
-        <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p> -->
+        <div class="infomation" v-for="(item, post_index) in fire_data">
+            <template v-if="post_index < max">
+                <!-- <p>{{post_index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -10,8 +10,8 @@
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
 
                             <template v-if="item.media != null">  
-                                <template v-for="(url, url_num) in item.media">  
-                                    <template v-if="url_num == 'url' + page[index]">
+                                <template v-for="(url, url_name) in item.media">  
+                                    <template v-if="url_name == 'url' + page[post_index]">
                                         <template v-if="url.media_type == 'video'">
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
@@ -22,43 +22,22 @@
                                 </template>
                             </template>
 
-                            <template v-if="page[index] > 0">
-                                <div class="left-btn" @click="prevPage(index)"><p>前へ</p></div>
+                            <template v-if="page[post_index] > 0">
+                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
                             </template>
                             
-                            <template v-if="item.media.url3">
-                                <!-- <p>url3まである</p> -->
-                                <template v-if="page[index] != 3">
-                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                </template>
-                            </template>
-                            <template v-else-if="item.media.url3">
-                                <!-- <p>url2まである</p> -->
-                                <template v-if="page[index] != 2">
-                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                </template>
-                            </template>
-                            <template v-else-if="item.media.url1">
-                                <!-- <p>url1まである</p> -->
-                                <template v-if="page[index] != 1">
-                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                </template>
-                            </template>
-                            <template v-else-if="item.media.url0">
-                                <!-- <p>url0しかない</p> -->
-                                <template v-if="page[index] != 0">
-                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                </template>
+                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                             </template>
 
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/TwitterIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -78,9 +57,9 @@
                             </template>
                             <template v-else>
 
-                                <template v-for="(url, url_num) in item.media">
+                                <template v-for="(url, url_name) in item.media">
                                     <!-- <p>確認用</p> -->
-                                    <template v-if="url_num == 'url' + page[index]">
+                                    <template v-if="url_name == 'url' + page[post_index]">
                                         <template v-if="url.media_type == 'VIDEO'">
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
                                         </template>
@@ -89,80 +68,25 @@
                                         </template>
                                     </template>
                                 </template>
-                                <template v-if="page[index] > 0">
-                                    <div class="left-btn" @click="prevPage(index)"><p>前へ</p></div>
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
                                 </template>
 
-                                <template v-if="item.media.url9">
-                                    <!-- <p>url9まである</p> -->
-                                    <template v-if="page[index] != 9">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>                                    
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
-                                <template v-else-if="item.media.url8">
-                                    <!-- <p>url8まである</p> -->
-                                    <template v-if="page[index] != 8">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>      
-                                <template v-else-if="item.media.url7">
-                                    <!-- <p>url7まである</p> -->
-                                    <template v-if="page[index] != 7">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>     
-                                <template v-else-if="item.media.url6">
-                                    <!-- <p>url6まである</p> -->
-                                    <template v-if="page[index] != 6">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>              
-                                <template v-else-if="item.media.url5">
-                                    <!-- <p>url5まである</p> -->
-                                    <template v-if="page[index] != 5">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>       
-                                <template v-else-if="item.media.url4">
-                                    <!-- <p>url4まである</p> -->
-                                    <template v-if="page[index] != 4">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>                                                                                                                                
-                                <template v-else-if="item.media.url3">
-                                    <!-- <p>url3まである</p> -->
-                                    <template v-if="page[index] != 3">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>
-                                <template v-else-if="item.media.url3">
-                                    <!-- <p>url2まである</p> -->
-                                    <template v-if="page[index] != 2">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>
-                                <template v-else-if="item.media.url1">
-                                    <!-- <p>url1まである</p> -->
-                                    <template v-if="page[index] != 1">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>
-                                <template v-else-if="item.media.url0">
-                                    <!-- <p>url0しかない</p> -->
-                                    <template v-if="page[index] != 0">
-                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
-                                    </template>
-                                </template>
+
+                                
                             </template>
 
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/InstagramIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -173,7 +97,7 @@
 
     <div>
         <template v-if="max < fire_data.length">
-            <p>{{max}}</p>
+            <!-- <p>{{max}}</p> -->
             <p  v-on:click="displayMore">more</p>
         </template>
     </div>
@@ -182,34 +106,38 @@
 
 
 <script>
+const posts_num = 30  //表示する投稿数
+const get_posts_num = 100  //取得してくる投稿数
+
 export default {
     name: "topPage",
     data() {
         return {
-            max: 30,
-            page: [0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0]
+            max: posts_num,
+            page: this.InitializeArray(get_posts_num)
         }
     },
     methods: {
-        nextPage(index){
-            // console.log(index)
-            this.page[index] ++;
+        nextPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] ++;
         },
-        prevPage(index){
-            // console.log(index)
-            this.page[index] --;
+        prevPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] --;
         },        
         displayMore() {
-            this.max += 30
+            this.max += posts_num
+        },
+        getObjLength (obj) {
+            // console.log(Object.keys(num).length)
+            return Object.keys(obj).length
+        },
+        InitializeArray(num) {
+            let array = Array(num)
+            array.fill(0)
+            // console.log(array)
+            return array
         }
     },    
     computed: {

--- a/front/HaCollect/src/components/topPage.vue
+++ b/front/HaCollect/src/components/topPage.vue
@@ -2,7 +2,7 @@
     <div class="hello">
         <div class="infomation" v-for="(item, index) in fire_data">
             <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
+                <!-- <p>{{index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
@@ -25,9 +25,30 @@
                             <template v-if="page[index] > 0">
                                 <div class="left-btn" @click="prevPage(index)"><p>前へ</p></div>
                             </template>
-                            <!-- <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div> -->
-                            <template v-if="page[index] < 3">
-                                <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                            
+                            <template v-if="item.media.url3">
+                                <!-- <p>url3まである</p> -->
+                                <template v-if="page[index] != 3">
+                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                </template>
+                            </template>
+                            <template v-else-if="item.media.url3">
+                                <!-- <p>url2まである</p> -->
+                                <template v-if="page[index] != 2">
+                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                </template>
+                            </template>
+                            <template v-else-if="item.media.url1">
+                                <!-- <p>url1まである</p> -->
+                                <template v-if="page[index] != 1">
+                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                </template>
+                            </template>
+                            <template v-else-if="item.media.url0">
+                                <!-- <p>url0しかない</p> -->
+                                <template v-if="page[index] != 0">
+                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                </template>
                             </template>
 
                             <div class="ac-box">
@@ -58,6 +79,7 @@
                             <template v-else>
 
                                 <template v-for="(url, url_num) in item.media">
+                                    <!-- <p>確認用</p> -->
                                     <template v-if="url_num == 'url' + page[index]">
                                         <template v-if="url.media_type == 'VIDEO'">
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
@@ -71,8 +93,65 @@
                                     <div class="left-btn" @click="prevPage(index)"><p>前へ</p></div>
                                 </template>
 
-                                <template v-if="page[index] < 9">
-                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                <template v-if="item.media.url9">
+                                    <!-- <p>url9まである</p> -->
+                                    <template v-if="page[index] != 9">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>                                    
+                                </template>
+                                <template v-else-if="item.media.url8">
+                                    <!-- <p>url8まである</p> -->
+                                    <template v-if="page[index] != 8">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>      
+                                <template v-else-if="item.media.url7">
+                                    <!-- <p>url7まである</p> -->
+                                    <template v-if="page[index] != 7">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>     
+                                <template v-else-if="item.media.url6">
+                                    <!-- <p>url6まである</p> -->
+                                    <template v-if="page[index] != 6">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>              
+                                <template v-else-if="item.media.url5">
+                                    <!-- <p>url5まである</p> -->
+                                    <template v-if="page[index] != 5">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>       
+                                <template v-else-if="item.media.url4">
+                                    <!-- <p>url4まである</p> -->
+                                    <template v-if="page[index] != 4">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                                                                                                                
+                                <template v-else-if="item.media.url3">
+                                    <!-- <p>url3まである</p> -->
+                                    <template v-if="page[index] != 3">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>
+                                <template v-else-if="item.media.url3">
+                                    <!-- <p>url2まである</p> -->
+                                    <template v-if="page[index] != 2">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>
+                                <template v-else-if="item.media.url1">
+                                    <!-- <p>url1まである</p> -->
+                                    <template v-if="page[index] != 1">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
+                                </template>
+                                <template v-else-if="item.media.url0">
+                                    <!-- <p>url0しかない</p> -->
+                                    <template v-if="page[index] != 0">
+                                        <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                    </template>
                                 </template>
                             </template>
 
@@ -93,7 +172,10 @@
     </div>
 
     <div>
-        <p  v-on:click="displayMore">more</p>
+        <template v-if="max < fire_data.length">
+            <p>{{max}}</p>
+            <p  v-on:click="displayMore">more</p>
+        </template>
     </div>
 </template>
 

--- a/front/HaCollect/src/components/topPage.vue
+++ b/front/HaCollect/src/components/topPage.vue
@@ -8,16 +8,25 @@
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
-                                    <template v-if="url.media_type == 'video'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                            <template v-if="item.media != null">  
+                                <template v-for="(url, index) in item.media">  
+                                    <template v-if="index == 'url' + page">
+                                        <template v-if="url.media_type == 'video'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> 
+                                        </template>
                                     </template>
                                 </template>
                             </template>
+                            <div class="left-btn" @click="prevPage"><p>前へ</p></div>
+                            <div class="right-btn" @click="nextPage"><p>次へ</p></div>
+                            <!-- <template v-if="item.media != null">
+                                <div class="right-btn" @click="nextPage"><p>次へ</p></div>
+                            </template> -->
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
@@ -44,15 +53,21 @@
                                 </template>
                             </template>
                             <template v-else>
-                                <template v-for="(url) in item.media">
-                                    <template v-if="url.media_type == 'VIDEO'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                                <template v-for="(url, index) in item.media">
+                                    <template v-if="index == 'url' + page">
+                                        <template v-if="url.media_type == 'VIDEO'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                        </template>
                                     </template>
                                 </template>
+                                <div class="left-btn" @click="prevPage"><p>前へ</p></div>
+                                <div class="right-btn" @click="nextPage"><p>次へ</p></div>
                             </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[index]" name="accordion-1" type="checkbox" />
@@ -76,24 +91,42 @@
 
 
 
-
 <script>
 export default {
     name: "topPage",
     data() {
         return {
-            max: 100
+            max: 30,
+            page: 0,
+            // b: 'item.media.url0.media_url'
         }
     },
     methods: {
+        nextPage(){
+            // if(this.page + 1 >= this.fire_data.SNS_type){
+            //     this.page = 0
+            //     return;
+            // }
+            this.page ++;
+        },
+        prevPage(){
+            if(this.page <= 0){
+                return;
+            }
+            this.page --;
+        },        
         displayMore() {
-            this.max += 100
+            this.max += 30
         }
     },    
     computed: {
         fire_data: function () {
             return this.$store.state.top_fire_data   //store.jsのstateを参照
         },
+        // a: function () {
+        //     // return 'item.media.url' + String(this.page) + '.media_url'
+        //     return 'item.media.url0.media_url'
+        // }
     },
 };
 </script>
@@ -101,6 +134,23 @@ export default {
 
 
 <style scoped>
+.VueCarousel{
+    height: 300px;
+}
+.VueCarousel-wrapper, .VueCarousel-inner, .VueCarousel-slide{
+    height: 100% !important;
+}
+.VueCarousel-slide .slider-inner {
+    height: 100%;
+    background-color: #62caaa; 
+    display: flex; 
+    justify-content: center; 
+    align-items: center; 
+    color: #fff; 
+    border: 2px solid #fff;
+    font-size: 30px; 
+    border-radius: 10px;
+}
 .hello {
     padding-top: 80px;
 }

--- a/front/HaCollect/src/components/topPage.vue
+++ b/front/HaCollect/src/components/topPage.vue
@@ -10,8 +10,8 @@
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
 
                             <template v-if="item.media != null">  
-                                <template v-for="(url, index) in item.media">  
-                                    <template v-if="index == 'url' + page">
+                                <template v-for="(url, url_num) in item.media">  
+                                    <template v-if="url_num == 'url' + page[index]">
                                         <template v-if="url.media_type == 'video'">
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
@@ -21,11 +21,14 @@
                                     </template>
                                 </template>
                             </template>
-                            <div class="left-btn" @click="prevPage"><p>前へ</p></div>
-                            <div class="right-btn" @click="nextPage"><p>次へ</p></div>
-                            <!-- <template v-if="item.media != null">
-                                <div class="right-btn" @click="nextPage"><p>次へ</p></div>
-                            </template> -->
+
+                            <template v-if="page[index] > 0">
+                                <div class="left-btn" @click="prevPage(index)"><p>前へ</p></div>
+                            </template>
+                            <!-- <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div> -->
+                            <template v-if="page[index] < 3">
+                                <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                            </template>
 
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
@@ -54,8 +57,8 @@
                             </template>
                             <template v-else>
 
-                                <template v-for="(url, index) in item.media">
-                                    <template v-if="index == 'url' + page">
+                                <template v-for="(url, url_num) in item.media">
+                                    <template v-if="url_num == 'url' + page[index]">
                                         <template v-if="url.media_type == 'VIDEO'">
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
                                         </template>
@@ -64,8 +67,13 @@
                                         </template>
                                     </template>
                                 </template>
-                                <div class="left-btn" @click="prevPage"><p>前へ</p></div>
-                                <div class="right-btn" @click="nextPage"><p>次へ</p></div>
+                                <template v-if="page[index] > 0">
+                                    <div class="left-btn" @click="prevPage(index)"><p>前へ</p></div>
+                                </template>
+
+                                <template v-if="page[index] < 9">
+                                    <div class="right-btn" @click="nextPage(index)"><p>次へ</p></div>
+                                </template>
                             </template>
 
                             <div class="ac-box">
@@ -97,23 +105,26 @@ export default {
     data() {
         return {
             max: 30,
-            page: 0,
-            // b: 'item.media.url0.media_url'
+            page: [0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0]
         }
     },
     methods: {
-        nextPage(){
-            // if(this.page + 1 >= this.fire_data.SNS_type){
-            //     this.page = 0
-            //     return;
-            // }
-            this.page ++;
+        nextPage(index){
+            // console.log(index)
+            this.page[index] ++;
         },
-        prevPage(){
-            if(this.page <= 0){
-                return;
-            }
-            this.page --;
+        prevPage(index){
+            // console.log(index)
+            this.page[index] --;
         },        
         displayMore() {
             this.max += 30
@@ -123,10 +134,6 @@ export default {
         fire_data: function () {
             return this.$store.state.top_fire_data   //store.jsのstateを参照
         },
-        // a: function () {
-        //     // return 'item.media.url' + String(this.page) + '.media_url'
-        //     return 'item.media.url0.media_url'
-        // }
     },
 };
 </script>
@@ -134,23 +141,7 @@ export default {
 
 
 <style scoped>
-.VueCarousel{
-    height: 300px;
-}
-.VueCarousel-wrapper, .VueCarousel-inner, .VueCarousel-slide{
-    height: 100% !important;
-}
-.VueCarousel-slide .slider-inner {
-    height: 100%;
-    background-color: #62caaa; 
-    display: flex; 
-    justify-content: center; 
-    align-items: center; 
-    color: #fff; 
-    border: 2px solid #fff;
-    font-size: 30px; 
-    border-radius: 10px;
-}
+
 .hello {
     padding-top: 80px;
 }

--- a/front/HaCollect/src/components/tourPage.vue
+++ b/front/HaCollect/src/components/tourPage.vue
@@ -1,35 +1,46 @@
 <template>
     <div class="hello">
+        <!-- 投稿の情報(fire_data)をitemの変数に格納    item: {TwitterとInstaでキーの数が違ったり、キーはたくさんあるからRealtime databaseで確認してくれ} -->
         <div class="infomation" v-for="(item, post_index) in fire_data">
+            <!-- 表示する投稿の数だけ表示（最初はmax=30件表示） -->
             <template v-if="post_index < max">
                 <!-- <p>{{post_index}}</p> -->
                 <div class="item">
+
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
                             <template v-if="item.media != null">  
+                                <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
                                 <template v-for="(url, url_name) in item.media">  
+                                    <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
                                     <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'video'">
+                                        <!-- 動画かどうかチェック -->
+                                        <template v-if="url.media_type == 'video'">    
                                             <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
                                         </template>
+                                        <!-- 画像だったら以下実行 -->
                                         <template v-else>
                                             <img class="card_Image" v-bind:src=url.media_url> 
                                         </template>
                                     </template>
+                                </template>                            
+
+                                <!-- 画像スライダーのボタン(Twitter) -->
+                                <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>                
+                                <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->            
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
                                 </template>
                             </template>
 
-                            <template v-if="page[post_index] > 0">
-                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                            </template>
-                            
-                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                            </template>
-
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -40,45 +51,57 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Twitter投稿の終わり -->
+
                     <!-- インスタグラムの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Instagram'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Instagram.png" />
-                            <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
-                                <template v-if="item.media_type == 'VIDEO'">
-                                    <!-- メディアの種類が動画だったら... -->
-                                    <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
-                                </template>
-                                <template v-else>
-                                    <!-- メディアの種類が動画以外だったら... -->
-                                    <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
-                                </template>
-                            </template>
-                            <template v-else>
-
-                                <template v-for="(url, url_name) in item.media">
-                                    <!-- <p>確認用</p> -->
-                                    <template v-if="url_name == 'url' + page[post_index]">
-                                        <template v-if="url.media_type == 'VIDEO'">
-                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                        </template>
-                                        <template v-else>
-                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
-                                        </template>
+                            <!-- 画像情報 -->
+                            <!-- 画像や動画があるかチェック -->
+                            <template v-if="item.media_type != null">
+                                <!-- その投稿が1枚の画像or動画のみだったら    CAROUSEL_ALBUM：複数メディアが含まれている状態  -->
+                                <template v-if="item.media_type != 'CAROUSEL_ALBUM'">
+                                    <!-- そのメディアが動画だったら -->
+                                    <template v-if="item.media_type == 'VIDEO'">
+                                        <iframe class="card_Movie" v-bind:src=item.media_url></iframe> <!-- 動画のurl -->
+                                    </template>
+                                    <!-- そのメディアが画像だったら -->
+                                    <template v-else>
+                                        <img class="card_Image" v-bind:src=item.media_url> <!-- 画像のurl -->
                                     </template>
                                 </template>
-                                <template v-if="page[post_index] > 0">
-                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
-                                </template>
 
-                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
-                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
-                                </template>
+                                <!-- その投稿が複数メディアある投稿だったら  -->
+                                <template v-else>
+                                    <!-- urlの情報(item.media)をurlの変数に格納     url: { url0 {media_type: メディアの種類,   media_url:メディアのURL},    url1 {media_type: メディアの種類,   media_url:メディアのURL} .....}となっている -->
+                                    <template v-for="(url, url_name) in item.media">
+                                        <!-- urlのキー名(url0,url1)のうち一つを表示する。（最初はurl0を表示） -->
+                                        <template v-if="url_name == 'url' + page[post_index]">
+                                            <!-- 動画かどうかチェック -->
+                                            <template v-if="url.media_type == 'VIDEO'">
+                                                <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                            </template>
+                                            <!-- 画像だったら以下実行 -->
+                                            <template v-else>
+                                                <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                            </template>
+                                        </template>
+                                    </template>
 
-                                
+                                    <!-- 画像スライダーのボタン(Instagram) -->
+                                    <!-- 表示されている画像が1枚目以降の時、前へボタンを表示 -->                                
+                                    <template v-if="page[post_index] > 0">
+                                        <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                    </template>
+                                    <!-- 各投稿の最大画像枚数に達するまで、次へボタンを表示 -->   
+                                    <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                        <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                    </template>
+                                </template>                                
                             </template>
 
+                            <!-- テキスト情報 -->
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
                                 <input :id="[post_index]" name="accordion-1" type="checkbox" />
@@ -89,13 +112,15 @@
                                 <label :for="[post_index]"></label>
                             </div>
                         </div>
-                    </template>
+                    </template> <!-- Instagram投稿の終わり -->
+
                 </div>
             </template>
         </div>
     </div>
 
     <div>
+        <!-- 投稿表示限界数(fire_data.length)に達するまでmoreボタンを表示 -->
         <template v-if="max < fire_data.length">
             <!-- <p>{{max}}</p> -->
             <p  v-on:click="displayMore">more</p>
@@ -114,26 +139,31 @@ export default {
     name: "tourPage",
     data() {
         return {
-            max: posts_num,
-            page: this.InitializeArray(get_posts_num)
+            max: posts_num,  //表示する投稿数
+            page: this.InitializeArray(get_posts_num)   //urlの番号を格納する配列？
         }
     },
     methods: {
+        // 画像スライダーの一つ次の画像に移る関数
         nextPage(post_index){
             // console.log(post_index)
             this.page[post_index] ++;
         },
+        // 画像スライダーの一つ前の画像に移る関数
         prevPage(post_index){
             // console.log(post_index)
             this.page[post_index] --;
-        },        
+        },
+        // 投稿の表示数を増やす関数        
         displayMore() {
             this.max += posts_num
         },
+        // オブジェクトに含まれるキーの数を返す関数
         getObjLength (obj) {
-            // console.log(Object.keys(num).length)
+            // console.log(Object.keys(obj).length)
             return Object.keys(obj).length
         },
+        // 配列を作ってくれる関数
         InitializeArray(num) {
             let array = Array(num)
             array.fill(0)

--- a/front/HaCollect/src/components/tourPage.vue
+++ b/front/HaCollect/src/components/tourPage.vue
@@ -1,31 +1,43 @@
 <template>
     <div class="hello">
-        <div class="infomation" v-for="(item, index) in fire_data">
-            <template v-if="index < max">
-                <!-- <p>{{index}}</p>   確認用 -->
+        <div class="infomation" v-for="(item, post_index) in fire_data">
+            <template v-if="post_index < max">
+                <!-- <p>{{post_index}}</p> -->
                 <div class="item">
                     <!-- ツイッターの投稿の表示 -->
                     <template v-if="item.SNS_type == 'Twitter'">
                         <div class="card_All">
                             <img class="card_Head" src="../assets/SNScolor_Twitter.png" />
-                            <template v-if="item.media != null">  <!-- メディア情報がある場合 -->
-                                <template v-for="(url) in item.media">  <!-- メディアキーの中にあるurlを取り出す -->
-                                    <template v-if="url.media_type == 'video'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                            <template v-if="item.media != null">  
+                                <template v-for="(url, url_name) in item.media">  
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'video'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe>
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> 
+                                        </template>
                                     </template>
                                 </template>
                             </template>
+
+                            <template v-if="page[post_index] > 0">
+                                <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                            </template>
+                            
+                            <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                            </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/TwitterIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -44,23 +56,37 @@
                                 </template>
                             </template>
                             <template v-else>
-                                <template v-for="(url) in item.media">
-                                    <template v-if="url.media_type == 'VIDEO'">
-                                        <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
-                                    </template>
-                                    <template v-else>
-                                        <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+
+                                <template v-for="(url, url_name) in item.media">
+                                    <!-- <p>確認用</p> -->
+                                    <template v-if="url_name == 'url' + page[post_index]">
+                                        <template v-if="url.media_type == 'VIDEO'">
+                                            <iframe class="card_Movie" v-bind:src=url.media_url></iframe> <!-- 動画のurl -->
+                                        </template>
+                                        <template v-else>
+                                            <img class="card_Image" v-bind:src=url.media_url> <!-- 画像のurl -->
+                                        </template>
                                     </template>
                                 </template>
+                                <template v-if="page[post_index] > 0">
+                                    <div class="left-btn" @click="prevPage(post_index)"><p>前へ</p></div>
+                                </template>
+
+                                <template v-if="page[post_index] < getObjLength(item.media) - 1">
+                                    <div class="right-btn" @click="nextPage(post_index)"><p>次へ</p></div>
+                                </template>
+
+                                
                             </template>
+
                             <div class="ac-box">
                                 <p>{{ item.date2 }}</p>
-                                <input :id="[index]" name="accordion-1" type="checkbox" />
+                                <input :id="[post_index]" name="accordion-1" type="checkbox" />
                                 <p class="card_Text">{{ item.text }}</p> <!-- テキスト(最初の文のみプレビュー) -->
                                 <a v-bind:href=item.link target="_blank" class="card_Link" rel="noopener noreferrer"><img
                                         src="../assets/InstagramIcon.png" /></a>
                                 <!-- リンク -->
-                                <label :for="[index]"></label>
+                                <label :for="[post_index]"></label>
                             </div>
                         </div>
                     </template>
@@ -70,7 +96,10 @@
     </div>
 
     <div>
-        <p  v-on:click="displayMore">more</p>
+        <template v-if="max < fire_data.length">
+            <!-- <p>{{max}}</p> -->
+            <p  v-on:click="displayMore">more</p>
+        </template>
     </div>
 </template>
 
@@ -78,18 +107,40 @@
 
 
 <script>
+const posts_num = 30  //表示する投稿数
+const get_posts_num = 100  //取得してくる投稿数
+
 export default {
     name: "tourPage",
     data() {
         return {
-            max: 100
+            max: posts_num,
+            page: this.InitializeArray(get_posts_num)
         }
     },
     methods: {
+        nextPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] ++;
+        },
+        prevPage(post_index){
+            // console.log(post_index)
+            this.page[post_index] --;
+        },        
         displayMore() {
-            this.max += 100
+            this.max += posts_num
+        },
+        getObjLength (obj) {
+            // console.log(Object.keys(num).length)
+            return Object.keys(obj).length
+        },
+        InitializeArray(num) {
+            let array = Array(num)
+            array.fill(0)
+            // console.log(array)
+            return array
         }
-    },        
+    },    
     computed: {
         fire_data: function () {
             return this.$store.state.tour_fire_data

--- a/front/HaCollect/src/store.js
+++ b/front/HaCollect/src/store.js
@@ -66,13 +66,18 @@ export const store = createStore({
             return new Promise(function(resolve, reject) {
                 try {
                     const que = query(ref(database, 'SNS_data/'), orderByChild('date'));  //SNS_dataを投稿日を秒数にしてマイナスをつけ、昇順でソートしたものをqueに格納する
+                    let roop_count = 0       //ループ回数
 
                     get(que).then((snapshot) => {   //snapshot->データ全体  childSnapshot->データ一つ
         
                         const data = [];   //あとでデータの挿入(下のcontext.commit)に使う用
-                        snapshot.forEach(childSnapshot => {
-                            // ↓変数dataにデータベースのデータ一つを格納する処理
-                            data.push(childSnapshot.val());
+                        snapshot.forEach((childSnapshot) => {
+                            if (roop_count < 100) {   //roopcountでループ回数を指定（現在100回ループ=データを全体で100個格納）
+                                // ↓変数dataにデータベースのデータ一つを格納する処理
+                                // console.log(roop_count)  //確認用
+                                data.push(childSnapshot.val());
+                                roop_count ++
+                            }
                         });
         
                         console.log(data);  //確認用


### PR DESCRIPTION
# 対応するPBI
- #21 

# 対応するTask
- #99

# 概要
画像スライダーの作成
（投稿の表示数の制限＆
投稿の読み込み制限＆
投稿を表示するボタンの作成もやってしまった）

# 変更点・追加点
- 画像スライダーを作成した
- データベースにある投稿データをある分だけすべて取得してきてしまうコードだったので。store.jsで取得してくるのは100件までと制限した
- 表示される投稿が100件取得してきていたら100件表示してしまい。表示するまでに読み込み時間かかってしまうので、表示する数を30件までとし、さらに表示させたい場合は、「moreボタン」を押すことで30件ずつ表示できるようにした。

# 疑問点
画像スライダーを動かすと画像表示まで若干ラグ？みたいなものがある。
事前に画像を読み込むみたいなことができないのだろうか？

# 発見した問題？
・画像サイズがバラバラであること
・動画の表示スタイルの違い
・ごはんカテゴリで再読み込みするとホームカテゴリに戻るが、リンクとしてはごはんカテゴリのままであること
・PC画面のとき、ニュースカテゴリを押したときだけ、検索バーが若干動くこと

# スクリーンショットなど(あれば)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

# チェックリスト
- [ ] 仕様と実際の実装はあっているか
- [ ] 無意味なコードは無いか
- [ ] 命名は適切か
- [ ] コーディング規約を守っているか
- [ ] その他気になる点が無いか
