### PR TITLE
add: ヘッダー周りのデザイン修正・投稿の展開ボタンの間隔修正を全ページに適用

### DIFF
--- a/front/HaCollect/src/App.vue
+++ b/front/HaCollect/src/App.vue
@@ -150,10 +150,11 @@ header {
 }
 .header-inner {
     display: flex;
+    background: #fff;
     height: 70px;
     justify-content: space-between;
     align-items: center;
-    padding: 0 36px;
+    padding: 0 5px;
     margin: 0 auto;
 }
 .header-logoImg {
@@ -164,8 +165,8 @@ header {
     margin-top: 10px;
 }
 .searchArea {
-    width: 350px;
-    /* inputの幅           */
+    width: 500px;
+    /* inputの幅 */
     height: 35px;
     background-repeat: no-repeat;
     /* 背景は繰り返さない  */
@@ -173,13 +174,13 @@ header {
     /* 背景の位置          */
     background-size: auto 60%;
     /* 背景のサイズ        */
-    background-color: #eeeeee;
+    background-color: #fff;
     /* 背景色              */
     margin-top: 10px;
     /* サンプルは中央寄せ  */
     margin-left: 10px;
     /* アイコン間の左余白    */
-    border-radius: 9999px;
+    border-radius: 10px;
     /* 角丸                */
     color: #687684;
     /* 文字色              */
@@ -201,47 +202,51 @@ header {
     /* フォーカス時背景色  */
 }
 .header-inner2 {
-    background-color: #ffffff;
+    background-color: #fff;
     display: flex;
     justify-content: space-between;
     align-items: center;
     width: 100%;
     margin: 0 auto;
     position: fixed;
-    height: 60px;
+    height: 45px;
     z-index: 1;
 }
 .header-nav {
     display: flex;
-    overflow-x: auto;
+    overflow-x: scroll;
     white-space: nowrap;
-    height: 60px;
+    height: 45px;
+    width: 100%;
 }
 .header-nav label {
-    background: #FFFFFF;
+    background: #FFF;
     border-left: 1px solid #CCCCCC;
     border-right: 1px solid #CCCCCC;
+    border-bottom: 1px solid #bbbbbb;
     font-style: normal;
-    width: 125px;
+    width: 25%;
 }
 .pageChange {
     display: block;
     /* 扱いやすいようにblock要素にする */
-    font-size: 20px;
+    font-size: 16px;
     /* 任意のフォントサイズにする */
     font-weight: bold;
     /* 太字にする */
-    color: #000;
+    color: #808080;
     text-decoration-line: none;
-    padding: 5px 15px;
-    margin-top: 10px;
+    padding: 10px 15px;
 }
 .header-nav input:checked+ label {
-    background: #61d6d2;
-    border: 1px solid #61d6d2;
+    background: #FFFFFF;
+    border-top: 1px solid #bbbbbb;
+    border-left: 1px solid #bbbbbb;
+    border-right: 1px solid #bbbbbb;
+    border-bottom: none;
 }
 .header-nav input:checked+ label .pageChange {
-    color: #ffffff;
+    color: #000;
 }
 .header-nav input {
     display: none;
@@ -284,25 +289,25 @@ header {
     opacity: 0;
 }
 /* タブレット・スマートフォン用スタイル */
-@media(max-width: 971px) {
-    /* .header-logoImg {
+/* @media(max-width: 971px) {
+    .header-logoImg {
         width: 150px;
         margin-top: 10px;
-    } */
-    /* .searchArea {
-    width: 225px;
-    height: 30px;
-    } */
-}
-/* スマートフォン用スタイル */
-@media(max-width: 647px) {
-    .header-inner {
-        padding: 0 5px;
     }
     .searchArea {
+    width: 225px;
+    height: 30px;
+    }
+} */
+/* スマートフォン用スタイル */
+@media(min-width: 750px) {
+    .header-inner {
+        padding: 0 36px;
+    }
+    /* .searchArea {
         width: 225px;
         height: 30px;
-    }
+    } */
     /* .header-inner {
         display: block;
         height: 35px;

--- a/front/HaCollect/src/components/eatPage.vue
+++ b/front/HaCollect/src/components/eatPage.vue
@@ -246,7 +246,8 @@ export default {
 
 .card_Date {
     margin: auto;
-    font-size: 20px;
+    padding-right: 50px;
+    font-size: 18px;
 }
 
 .card_Image {
@@ -309,11 +310,11 @@ export default {
 }
 
 .ac-box label {
-    width: 50px;
-    height: 35px;
+    width: 75px;
+    height: 52px;
     font-size: 16px;
     text-align: center;
-    margin: 0 auto;
+    margin: 15px auto 0;
     line-height: 50px;
     position: relative;
     display: block;
@@ -355,12 +356,12 @@ export default {
     font-style: normal;
     width: 50px;
     height: 25px;
-    margin: 0 3px;
     display: block;
     font-size: 16px;
     color: #fff;
     text-decoration-line: none;
     padding: 5px 15px;
+    margin-top: 25px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/front/HaCollect/src/components/knowPage.vue
+++ b/front/HaCollect/src/components/knowPage.vue
@@ -247,9 +247,9 @@ export default {
 
 .card_Date {
     margin: auto;
-    font-size: 20px;
+    padding-right: 50px;
+    font-size: 18px;
 }
-
 .card_Image {
     max-width: 100%;
     height: auto;
@@ -310,11 +310,11 @@ export default {
 }
 
 .ac-box label {
-    width: 50px;
-    height: 35px;
+    width: 75px;
+    height: 52px;
     font-size: 16px;
     text-align: center;
-    margin: 0 auto;
+    margin: 15px auto 0;
     line-height: 50px;
     position: relative;
     display: block;
@@ -356,12 +356,12 @@ export default {
     font-style: normal;
     width: 50px;
     height: 25px;
-    margin: 0 3px;
     display: block;
     font-size: 16px;
     color: #fff;
     text-decoration-line: none;
     padding: 5px 15px;
+    margin-top: 25px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/front/HaCollect/src/components/searchResult.vue
+++ b/front/HaCollect/src/components/searchResult.vue
@@ -212,7 +212,7 @@ export default {
     margin: 0 auto;
     position: fixed;
     height: 30px;
-    margin-top: 60px;
+    margin-top: 45px;
     z-index: 1;
 }
 
@@ -276,7 +276,8 @@ export default {
 
 .card_Date {
     margin: auto;
-    font-size: 20px;
+    padding-right: 50px;
+    font-size: 18px;
 }
 
 .card_Image {
@@ -339,11 +340,11 @@ export default {
 }
 
 .ac-box label {
-    width: 50px;
-    height: 35px;
+    width: 75px;
+    height: 52px;
     font-size: 16px;
     text-align: center;
-    margin: 0 auto;
+    margin: 15px auto 0;
     line-height: 50px;
     position: relative;
     display: block;
@@ -385,12 +386,12 @@ export default {
     font-style: normal;
     width: 50px;
     height: 25px;
-    margin: 0 3px;
     display: block;
     font-size: 16px;
     color: #fff;
     text-decoration-line: none;
     padding: 5px 15px;
+    margin-top: 25px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/front/HaCollect/src/components/seePage.vue
+++ b/front/HaCollect/src/components/seePage.vue
@@ -246,7 +246,8 @@ export default {
 
 .card_Date {
     margin: auto;
-    font-size: 20px;
+    padding-right: 50px;
+    font-size: 18px;
 }
 
 .card_Image {
@@ -309,11 +310,11 @@ export default {
 }
 
 .ac-box label {
-    width: 50px;
-    height: 35px;
+    width: 75px;
+    height: 52px;
     font-size: 16px;
     text-align: center;
-    margin: 0 auto;
+    margin: 15px auto 0;
     line-height: 50px;
     position: relative;
     display: block;
@@ -355,12 +356,12 @@ export default {
     font-style: normal;
     width: 50px;
     height: 25px;
-    margin: 0 3px;
     display: block;
     font-size: 16px;
     color: #fff;
     text-decoration-line: none;
     padding: 5px 15px;
+    margin-top: 25px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/front/HaCollect/src/components/topPage.vue
+++ b/front/HaCollect/src/components/topPage.vue
@@ -245,7 +245,8 @@ export default {
 
 .card_Date {
     margin: auto;
-    font-size: 20px;
+    padding-right: 50px;
+    font-size: 18px;
 }
 
 .card_Image {
@@ -356,12 +357,12 @@ export default {
     font-style: normal;
     width: 50px;
     height: 25px;
-    margin: 0 3px;
     display: block;
     font-size: 16px;
     color: #fff;
     text-decoration-line: none;
     padding: 5px 15px;
+    margin-top: 25px;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
# 対応するPBI
- https://app.zenhub.com/workspaces/-63039094a8f9171f93314018/issues/funswift/swift2022c/21

# 対応するTask
- https://app.zenhub.com/workspaces/-63039094a8f9171f93314018/issues/funswift/swift2022c/37
- https://app.zenhub.com/workspaces/-63039094a8f9171f93314018/issues/funswift/swift2022c/73

# 概要
ヘッダーの諸々を修正したのと、別のプルリクでやった投稿デザインの余白部分がtopPageにしか適用されていなかったので、前ページに適用しました。

# 変更点・追加点
- ヘッダーのデザインを変更
- 検索バーの角を丸型→少し丸っぽい四角 に変更
- ロゴと検索バーの間を埋めた（検索バーを伸ばした）
- 投稿デザインの「文章全文表示ボタン」まわりの余白をもっとあけるように他のタスクで直したが、topPageしか直していなかったので他のページでも同じ余白になるように修正した。

# スクリーンショットなど(あれば)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

# チェックリスト
- [ ] 仕様と実際の実装はあっているか
- [ ] 無意味なコードは無いか
- [ ] 命名は適切か
- [ ] コーディング規約を守っているか
- [ ] その他気になる点が無いか
